### PR TITLE
mkdocs: add meta tags

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ edit_uri: blob/master/docs/
 
 theme:
   name: readthedocs
+  custom_dir: theme
   locale: en
   highlightjs: true
   hljs_languages:

--- a/theme/main.html
+++ b/theme/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block site_meta %}
+<meta name="description" content="OCaml for JavaScript developers">
+<meta name="ahrefs-site-verification" content="418209e997de7b3e1afdfd3575944e61695804a30ab7c7f5bf27f64d32935cda">
+{% endblock %}


### PR DESCRIPTION
adds a custom theme folder to mkdocs confic, so that we can customize `meta` tags:

https://www.mkdocs.org/user-guide/customizing-your-theme/