### PR TITLE
theme: add link to melange gh

### DIFF
--- a/theme/versions.html
+++ b/theme/versions.html
@@ -1,0 +1,13 @@
+<div class="rst-versions" role="note" aria-label="{% trans %}Versions{% endtrans %}">
+    <span class="rst-current-version" data-toggle="rst-current-version">
+        <span>
+            <a href="https://github.com/melange-re/melange" class="fa fa-github" style="color: #fcfcfc"> GitHub</a>
+        </span>
+      {% if page.previous_page %}
+        <span><a href="{{ page.previous_page.url|url }}" style="color: #fcfcfc">&laquo; {% trans %}Previous{% endtrans %}</a></span>
+      {% endif %}
+      {% if page.next_page %}
+        <span><a href="{{ page.next_page.url|url }}" style="color: #fcfcfc">{% trans %}Next{% endtrans %} &raquo;</a></span>
+      {% endif %}
+    </span>
+</div>


### PR DESCRIPTION
Fixes #45.

Replaces the `versions.html` fragment of the template, so that the GH link points to `melange-re/melange`. Based on [original readthedocs template](https://github.com/mkdocs/mkdocs/blob/562d5e14c1d2c914d42942ab2385822c04d5bc7b/mkdocs/themes/readthedocs/versions.html).