### PR TITLE
Fixed instructions on building app after an alias has been created

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -395,7 +395,7 @@ After these changes, once we build the project, we should still be able to run
 the application file with Node:
 
 ```bash
-$ dune build @app
+$ dune build @my-app
 $ node _build/default/app/app.js
 Jane
 ```


### PR DESCRIPTION
If the reader has been going through the example code and created an alias in the earlier section 'Using aliases', they need to build the project (in the 'Handling assets' section) using the alias `my-app`.