### PR TITLE
comm with js: add exports

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -436,8 +436,8 @@ to configure it to generate
 [ES6](https://en.wikipedia.org/wiki/ECMAScript#6th_Edition_-_ECMAScript_2015)
 modules.
 
-The place to do so is the `melange.emit` stanza. To configure Melange to
-generate ES6 modules, we will use the `module_systems` field:
+Use the `module_systems` field in the `melange.emit` stanza to emit
+ES6 modules:
 
 ```text
 (melange.emit

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -169,7 +169,8 @@ let () = Js.log(Lib.name);
 
 The `melange.emit` stanza tells Dune to generate JavaScript files from a set of
 libraries and modules. In-depth documentation about this stanza can be found in
-the [Dune docs](https://dune.readthedocs.io/en/stable/melange.html).
+the [Dune
+docs](https://dune.readthedocs.io/en/stable/melange.html#melange-emit).
 
 The file structure of the app should look something like this:
 
@@ -346,8 +347,8 @@ provides a way to specify these dependencies, depending on the stanza:
 - For `melange.emit` stanzas, a field `runtime_deps`
 
 Both fields are documented in the [Melange
-page](https://dune.readthedocs.io/en/stable/melange.html) of the Dune
-documentation site.
+page](https://dune.readthedocs.io/en/stable/melange.html#melange-emit) of the
+Dune documentation site.
 
 For the sake of learning how to work with assets in a Melange project, let’s say
 that we want to read the string in `Lib.name` from a text file. We will combine
@@ -436,7 +437,8 @@ to configure it to generate
 [ES6](https://en.wikipedia.org/wiki/ECMAScript#6th_Edition_-_ECMAScript_2015)
 modules.
 
-Use the `module_systems` field in the `melange.emit` stanza to emit
+Use the `module_systems` field in the [`melange.emit`
+stanza](https://dune.readthedocs.io/en/stable/melange.html#melange-emit) to emit
 ES6 modules:
 
 ```text

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -278,8 +278,9 @@ More generically:
   class="text-reasonml">$name.re</code>, placed in the relative workspace path
   `$path-to-source-file`
 
-The path to the generated JavaScript file from <code class="text-ocaml">$name.ml</code><code
-  class="text-reasonml">$name.re</code> will be:
+The path to the generated JavaScript file from <code
+  class="text-ocaml">$name.ml</code><code class="text-reasonml">$name.re</code>
+  will be:
 
 ```text
 _build/default/$melange-emit-folder/$target/$path-to-source-file/$name.js
@@ -423,3 +424,33 @@ Melange developers. For further details about how Dune works and its integration
 with Melange, check the [Dune documentation](https://dune.readthedocs.io/), and
 the [Melange opam
 template](https://github.com/melange-re/melange-opam-template).
+
+#### CommonJS or ES6 modules
+
+Melange produces JavaScript modules that export the functions they declare, and
+declare imports for the values and modules they depend on.
+
+By default, Melange will produce
+[CommonJS](https://en.wikipedia.org/wiki/CommonJS) modules, but it is possible
+to configure it to generate
+[ES6](https://en.wikipedia.org/wiki/ECMAScript#6th_Edition_-_ECMAScript_2015)
+modules.
+
+The place to do so is the `melange.emit` stanza. To configure Melange to
+generate ES6 modules, we will use the `module_systems` field:
+
+```text
+(melange.emit
+ (target app)
+ (alias my-app)
+ (libraries lib)
+ (module_systems es6))
+```
+
+If no extension is specified, the resulting JavaScript files will use `.js`. You
+can specify a different extension with a pair `(<module_system> <extension>)`,
+e.g. `(module_systems (es6 mjs))`. Multiple module systems can be used in the
+same field as long as their extensions are different. For example,
+`(module_systems commonjs (es6 mjs))` will produce one set of JavaScript files
+using CommonJS and the `.js` extension, and another using ES6 and the `.mjs`
+extension.

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -3034,7 +3034,7 @@ preventing any Melange code from creating values of such type.
 
 As mentioned in the [build system
 section](build-system.md#commonjs-or-es6-modules), Melange allows to produce
-both CommonJS and ES6 modules. In any of both cases, there is nothing special to
+both CommonJS and ES6 modules. In both cases, there is nothing special to
 do to use your Melange-generated JavaScript code from any hand-written
 JavaScript file.
 
@@ -3070,7 +3070,7 @@ export {
 }
 ```
 
-So one can use either `require` or `import` (depending on the modules system of
+So one can use either `require` or `import` (depending on the module system of
 choice) to import the `print` value in a JavaScript file.
 
 ### Default ES6 values

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -3034,9 +3034,8 @@ preventing any Melange code from creating values of such type.
 
 As mentioned in the [build system
 section](build-system.md#commonjs-or-es6-modules), Melange allows to produce
-both CommonJS and ES6 modules. In both cases, there is nothing special to
-do to use your Melange-generated JavaScript code from any hand-written
-JavaScript file.
+both CommonJS and ES6 modules. In both cases, using Melange-generated JavaScript
+code from any hand-written JavaScript file works as expected.
 
 The following definition:
 

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -3029,3 +3029,77 @@ type person =
 The accessors `nameGet` and `ageGet` will still be generated, but not the
 constructor `person`. This is useful when binding to JavaScript objects while
 preventing any Melange code from creating values of such type.
+
+## Use Melange code from JavaScript
+
+As mentioned in the [build system
+section](build-system.md#commonjs-or-es6-modules), Melange allows to produce
+both CommonJS and ES6 modules. In any of both cases, there is nothing special to
+do to use your Melange-generated JavaScript code from any hand-written
+JavaScript file.
+
+The following definition:
+
+```ocaml
+let print name = "Hello" ^ name
+```
+```reasonml
+let print = name => "Hello" ++ name;
+```
+
+Will generate this JavaScript code, when using CommonJS (the default):
+
+```js
+function print(name) {
+  return "Hello" + name;
+}
+
+exports.print = print;
+```
+
+When using ES6 (through the `(module_systems es6)` field in `melange.emit`) this
+code will be generated:
+
+```js
+function print(name) {
+  return "Hello" + name;
+}
+
+export {
+  print ,
+}
+```
+
+So one can use either `require` or `import` (depending on the modules system of
+choice) to import the `print` value in a JavaScript file.
+
+### Default ES6 values
+
+One special case occur when working with JavaScript imports in ES6 modules that
+look like this:
+
+```js
+import ten from 'numbers.js';
+```
+
+This import expects `numbers.js` to have a default export, like:
+
+```js
+export default ten = 10;
+```
+
+To emulate this kind of exports from Melange, one just needs to define a
+`default` value.
+
+For example, in a file named <code class="text-ocaml">numbers.ml</code><code
+class="text-reasonml">numbers.re</code>:
+
+```ocaml
+let default = 10
+```
+```reasonml
+let default = 10;
+```
+
+That way, Melange will set the value on the `default` export so it can be
+consumed as default import on the JavaScript side.


### PR DESCRIPTION
Fixes #18.

- Adds some docs about `module_systems` field in "Build system"
- Adds a section "Use Melange code from JavaScript" in "Comm with JS"