### PR TITLE
Publish versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,4 +15,8 @@ jobs:
         with:
           python-version: 3.x
       - run: python3 -m pip install -r ./pip-requirements.txt
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
       - run: mike deploy --push unstable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,4 +19,5 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+      - run: git fetch origin gh-pages --depth=1
       - run: mike deploy --push unstable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - publish-versions # TODO: remove
 
 jobs:
   deploy:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -15,4 +15,8 @@ jobs:
           python-version: 3.x
       - run: python3 -m pip install -r ./pip-requirements.txt
       - run: mike deploy ${{  github.ref_name }}
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
       - run: mike set-default --push ${{  github.ref_name }}

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -1,10 +1,9 @@
-name: deploy
+name: publish-version
 
 on:
   push:
-    branches:
-      - master
-      - publish-versions # TODO: remove
+    tags:
+      - 'v*'
 
 jobs:
   deploy:
@@ -15,4 +14,5 @@ jobs:
         with:
           python-version: 3.x
       - run: python3 -m pip install -r ./pip-requirements.txt
-      - run: mike deploy --push unstable
+      - run: mike deploy ${{  github.ref_name }}
+      - run: mike set-default --push ${{  github.ref_name }}

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -19,4 +19,5 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+      - run: git fetch origin gh-pages --depth=1
       - run: mike set-default --push ${{  github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -51,5 +51,7 @@ dune build @re --auto-promote
 
 ## Publishing
 
-Publishing is done automatically from `master`. To publish manually, run `mkdocs
-gh-deploy`.
+Publishing is done automatically from GitHub actions:
+- Every commit to `master` will publish in the `unstable` folder
+- Every tag pushed with the `v*` format will publish on its correponding folder,
+  and set it as default

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
 plugins:
   - search
   - print-site
+  - mike
 
 nav:
   - Home: index.md

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,2 +1,3 @@
 mkdocs==1.4.3
 mkdocs-print-site-plugin==2.3.4
+mike==1.1.2

--- a/theme/CNAME
+++ b/theme/CNAME
@@ -1,1 +1,0 @@
-melange.re

--- a/theme/robots.txt
+++ b/theme/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://melange-re.github.io/sitemap.xml


### PR DESCRIPTION
Fixes #47.

Uses [mike](https://github.com/jimporter/mike) to achieve so. The process is quite simple, `mike` handles folders for each version in the `gh-pages` branch.

- Pushes to `master` deploy to the `unstable` version
- A GH action is configured so that new tags with the `v*` format deploy a new version with the tag name, aliased to `stable`.