### PR TITLE
Add looking forward section to rationale page

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -119,10 +119,10 @@ Melange.
 
 ## Looking forward
 
-While reaching version 1 marks a major milestone for Melange, it is
-only the beginning of the journey.  The Melange team remains committed to
-continuously improving Melange, ensuring it remains a robust and
-efficient tool for OCaml developers targeting the JavaScript platform.
+While reaching v1.0 marks a major milestone for Melange, it is only the 
+beginning of the journey. The Melange team remains committed to
+continuously improving Melange, ensuring it remains a robust and efficient
+tool for OCaml developers targeting the JavaScript platform.
 The [Q2 2023
 roadmap](https://docs.google.com/document/d/1279euT9LeJIkwAUYqazqeh2lc8c7TLQap2_2vBNcK4w/)
 includes short and long term goals for the project.

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -116,3 +116,16 @@ completion in Spring 2023, with the [migration of Ahrefs frontend codebase to
 Melange](https://tech.ahrefs.com/ahrefs-is-now-built-with-melange-b14f5ec56df4)
 and the new public releases that support it: version 3.8 of Dune and 1.0 of
 Melange.
+
+## Looking forward
+
+While reaching version 1 marks a major milestone for Melange, it is
+only the beginning of the journey.  The Melange team remains committed to
+continuously improving Melange, ensuring it remains a robust and
+efficient tool for OCaml developers targeting the JavaScript platform.
+The [Q2 2023
+roadmap](https://docs.google.com/document/d/1279euT9LeJIkwAUYqazqeh2lc8c7TLQap2_2vBNcK4w/)
+includes short and long term goals for the project, including
+cherry-picking relevant upstream patches from the ReScript compiler,
+adding support for OCaml 5, supporting source maps, improving
+developer experience, and developing a playground for Melange.

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -125,7 +125,4 @@ continuously improving Melange, ensuring it remains a robust and
 efficient tool for OCaml developers targeting the JavaScript platform.
 The [Q2 2023
 roadmap](https://docs.google.com/document/d/1279euT9LeJIkwAUYqazqeh2lc8c7TLQap2_2vBNcK4w/)
-includes short and long term goals for the project, including
-cherry-picking relevant upstream patches from the ReScript compiler,
-adding support for OCaml 5, supporting source maps, improving
-developer experience, and developing a playground for Melange.
+includes short and long term goals for the project.


### PR DESCRIPTION
I thought it might be a good idea to add a looking forward section to the rationale page, since it has that nice history recap.

The text is based off of anmonteiro's [post](https://discuss.ocaml.org/t/ann-melange-1-0-compile-ocaml-reasonml-to-javascript/12305#looking-forward-11) on OCaml discuss forum, plus a small summary of future goals from the roadmap.

(Of course, feel free to close if you don't think this section is necessary!)

