### PR TITLE
odoc: publish api docs in Reason syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,14 @@ jobs:
           dune-cache: false # can cause trouble when generating melange docs in step below: https://github.com/ocaml/dune/issues/7720
       - name: Install all deps
         run: make install
-      - name: Generate melange docs
+      - name: Generate melange docs in ml syntax
         run: opam reinstall -y melange --with-doc
-      - name: Copy melange docs
-        run: cp -r _opam/.opam-switch/build/melange.dev/_build/default/_doc/_html docs
+      - name: Copy melange docs in ml syntax
+        run: cp -r _opam/.opam-switch/build/melange.dev/_build/default/_doc/_html docs/api/ml
+      - name: Generate melange docs in re syntax
+        run: ODOC_SYNTAX="re" opam reinstall -y melange --with-doc
+      - name: Copy melange docs in re syntax
+        run: cp -r _opam/.opam-switch/build/melange.dev/_build/default/_doc/_html docs/api/re
       - name: Check Reason syntax
         run: make check-reason
       - name: Build playground

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - reason-api-docs
     tags-ignore:
       - 'v*'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - reason-api-docs
     tags-ignore:
       - 'v*'
 

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -22,8 +22,12 @@ jobs:
         run: make install
       - name: Generate melange docs
         run: opam reinstall -y melange --with-doc
-      - name: Copy melange docs
-        run: cp -r _opam/.opam-switch/build/melange.dev/_build/default/_doc/_html docs
+      - name: Copy melange docs in ml syntax
+        run: cp -r _opam/.opam-switch/build/melange.dev/_build/default/_doc/_html docs/api/ml
+      - name: Generate melange docs in re syntax
+        run: ODOC_SYNTAX="re" opam reinstall -y melange --with-doc
+      - name: Copy melange docs in re syntax
+        run: cp -r _opam/.opam-switch/build/melange.dev/_build/default/_doc/_html docs/api/re
       - name: Check Reason syntax
         run: make check-reason
       - name: Build playground

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ _opam
 .DS_Store
 
 docs/playground
-docs/_html
+docs/api/ml
+docs/api/re

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,12 +2,17 @@
 
 Melange exposes three libraries:
 
-- A standard library, which mostly replicates that of OCaml for compatibility;
-see the docs: the [`Stdlib`](../_html/melange/Stdlib) library
-- Bindings to several browser and Node JavaScript APIs in the [`Js`
-  library](../_html/melange/Js).
-- Data structures and collection types in the [`Belt`
-  library](../_html/melange/Belt)
+- A standard library, which mostly replicates that of OCaml for compatibility:
+the <a class="text-ocaml" href="../api/ml/melange/Stdlib"><code>Stdlib</code>
+library</a><a class="text-reasonml"
+href="../api/re/melange/Stdlib"><code>Stdlib</code> library</a>
+- Bindings to several browser and Node JavaScript APIs in the <a
+class="text-ocaml" href="../api/ml/melange/Js"><code>Js</code> library</a><a
+class="text-reasonml" href="../api/re/melange/Js"><code>Js</code> library</a>
+- Data structures and collection types in the <a class="text-ocaml"
+href="../api/ml/melange/Belt"><code>Belt</code> library</a><a
+class="text-reasonml" href="../api/re/melange/Belt"><code>Belt</code>
+library</a>
 
 Using one or the other will depend on your application requirements, how much
 integration you need with existing JavaScript libraries, or other specific

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -391,9 +391,11 @@ class="text-reasonml">\-\></code>.
 As its name suggests, the pipe first operator is better suited for functions
 where the data is passed as the first argument.
 
-The functions in the [`Belt` library](../_html/melange/Belt) included with
-Melange have been designed with the data-first convention in mind, so they work
-best with the pipe first operator.
+The functions in the <a class="text-ocaml"
+href="../api/ml/melange/Belt"><code>Belt</code> library</a><a
+class="text-reasonml" href="../api/re/melange/Belt"><code>Belt</code>
+library</a> included with Melange have been designed with the data-first
+convention in mind, so they work best with the pipe first operator.
 
 For example, we can rewrite the example above using `Belt.List.map` and the pipe
 first operator:
@@ -460,8 +462,8 @@ This is how each Melange type is converted into JavaScript values:
 | array | array |
 | tuple `(3, 4)` | array `[3, 4]` |
 | bool | boolean |
-| [Js.Nullable.t](../_html/melange/Js/Nullable) | `null` / `undefined` |
-| [Js.Re.t](../_html/melange/Js/Re) | [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) |
+| <a class="text-ocaml" href="../api/ml/melange/Js/Nullable">Js.Nullable.t</a><a class="text-reasonml" href="../api/re/melange/Js/Nullable">Js.Nullable.t</a> | `null` / `undefined` | 
+| <a class="text-ocaml" href="../api/ml/melange/Js/Re">Js.Re.t</a><a class="text-reasonml" href="../api/re/melange/Js/Re">Js.Re.t</a> | [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) |
 | Option.t `None` | `undefined` |
 | Option.t <code class="text-ocaml">Some( Some .. Some (None))</code><code class="text-reasonml">Some(Some( .. Some(None)))</code> | internal representation |
 | Option.t <code class="text-ocaml">Some 2</code><code class="text-reasonml">Some(2)</code> | `2` |
@@ -576,9 +578,14 @@ You can surround the interpolation variable in parentheses too: `{j|你
 好，$(world)|j}`.
 
 To work with strings, the Melange standard library provides some utilities in
-the [`Stdlib.String` module](../_html/melange/Stdlib/String). The bindings to
-the native JavaScript functions to work with strings are in the [`Js.String`
-module](../_html/melange/Js/String).
+the <a class="text-ocaml"
+href="../api/ml/melange/Stdlib/String"><code>Stdlib.String</code> module</a><a
+class="text-reasonml"
+href="../api/re/melange/Stdlib/String"><code>Stdlib.String</code> module</a>.
+The bindings to the native JavaScript functions to work with strings are in the
+<a class="text-ocaml" href="../api/ml/melange/Js/String"><code>Js.String</code>
+module</a><a class="text-reasonml"
+href="../api/re/melange/Js/String"><code>Js.String</code> module</a>.
 
 #### Floating-point numbers
 
@@ -588,10 +595,14 @@ with a 53-bit mantissa and exponents from -1022 to 1023. This happens to be the
 same encoding as [JavaScript
 numbers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding),
 so values of these types can be used transparently between Melange code and
-JavaScript code. The Melange standard library provides a [`Stdlib.Float`
-module](../_html/melange/Stdlib/Float). The bindings to the JavaScript APIs that
-manipulate float values can be found in the
-[`Js.Float`](../_html/melange/Js/Float) module.
+JavaScript code. The Melange standard library provides a <a class="text-ocaml"
+href="../api/ml/melange/Stdlib/Float"><code>Stdlib.Float</code> module</a><a
+class="text-reasonml"
+href="../api/re/melange/Stdlib/Float"><code>Stdlib.Float</code> module</a>. The
+bindings to the JavaScript APIs that manipulate float values can be found in the
+<a class="text-ocaml" href="../api/ml/melange/Js/Float"><code>Js.Float</code>
+module</a><a class="text-reasonml"
+href="../api/re/melange/Js/Float"><code>Js.Float</code> module</a>.
 
 #### Integers
 
@@ -607,9 +618,14 @@ allowing for a larger range of representable integers in JavaScript compared to
 Melange. When dealing with large numbers, it is advisable to use floats instead.
 For instance, floats are used in bindings like `Js.Date`.
 
-The Melange standard library provides a [`Stdlib.Int`
-module](../_html/melange/Stdlib/Int). The bindings to work with JavaScript
-integers are in the [`Js.Int`](../_html/melange/Js/Int) module.
+The Melange standard library provides a <a class="text-ocaml"
+href="../api/ml/melange/Stdlib/Int"><code>Stdlib.Int</code> module</a><a
+class="text-reasonml"
+href="../api/re/melange/Stdlib/Int"><code>Stdlib.Int</code> module</a>. The
+bindings to work with JavaScript integers are in the <a class="text-ocaml"
+href="../api/ml/melange/Js/Int"><code>Js.Int</code> module</a><a
+class="text-reasonml" href="../api/re/melange/Js/Int"><code>Js.Int</code>
+module</a>.
 
 #### Arrays
 
@@ -618,11 +634,16 @@ arrays, all the values in a Melange array need to have the same type.
 
 Another difference is that OCaml arrays are fixed-sized, but on Melange side
 this constraint is relaxed. You can change an array’s length using functions
-like `Js.Array.push`, available in the bindings to the JavaScript APIs in
-[`Js.Array`](../_html/melange/Js/Array).
+like `Js.Array.push`, available in the bindings to the JavaScript APIs in the <a
+class="text-ocaml" href="../api/ml/melange/Js/Array"><code>Js.Array</code>
+module</a><a class="text-reasonml"
+href="../api/re/melange/Js/Array"><code>Js.Array</code> module</a>.
 
-Melange standard library also has a module to work with arrays, available in
-[`Stdlib.Array`](../_html/melange/Stdlib/Array) module.
+Melange standard library also has a module to work with arrays, available in the
+<a class="text-ocaml"
+href="../api/ml/melange/Stdlib/Array"><code>Stdlib.Array</code> module</a><a
+class="text-reasonml"
+href="../api/re/melange/Stdlib/Array"><code>Stdlib.Array</code> module</a>.
 
 #### Tuples
 
@@ -684,9 +705,11 @@ Will compile to:
 var r = /b/g;
 ```
 
-A regular expression like the above is of type `Js.Re.t`. The
-[`Js.Re`](../_html/melange/Js/Re) module provides the bindings to the JavaScript
-functions that operate over regular expressions.
+A regular expression like the above is of type `Js.Re.t`. The <a
+class="text-ocaml" href="../api/ml/melange/Js/Re"><code>Js.Re</code>
+module</a><a class="text-reasonml"
+href="../api/re/melange/Js/Re"><code>Js.Re</code> module</a> provides the
+bindings to the JavaScript functions that operate over regular expressions.
 
 ## Non-shared data types
 
@@ -699,11 +722,16 @@ them before doing so.
   [some helpers](#generate-getters-setters-and-constructors) to do so.
 - Exceptions
 - Option (a variant type): Better use the `Js.Nullable.fromOption` and
-  `Js.Nullable.toOption` functions in the [`Js.Nullable`
-  module](../_html/melange/Js/Nullable) to transform them into either `null` or
-  `undefined` values.
-- List (also a variant type): use `Array.of_list` and `Array.to_list` in the
-  [`Array` module](../_html/melange/Stdlib/Array).
+  `Js.Nullable.toOption` functions in the <a class="text-ocaml"
+  href="../api/ml/melange/Js/Nullable"><code>Js.Nullable</code> module</a><a
+  class="text-reasonml"
+  href="../api/re/melange/Js/Nullable"><code>Js.Nullable</code> module</a> to
+  transform them into either `null` or `undefined` values.
+- List (also a variant type): use `Array.of_list` and `Array.to_list` in the <a
+  class="text-ocaml"
+  href="../api/ml/melange/Stdlib/Array"><code>Stdlib.Array</code> module</a><a
+  class="text-reasonml"
+  href="../api/re/melange/Stdlib/Array"><code>Stdlib.Array</code> module</a>.
 - Character
 - Int64
 - Lazy values
@@ -1356,8 +1384,10 @@ Sometimes JavaScript objects are used as dictionaries. In these cases:
 
 For this particular use case of JavaScript objects, Melange exposes a specific
 type `Js.Dict.t`. The values and functions to work with values of this type are
-defined in the [`Js.Dict`](../_html/melange/Js/Dict) module, with operations
-like `get`, `set`, etc.
+defined in the <a class="text-ocaml"
+href="../api/ml/melange/Js/Dict"><code>Js.Dict</code> module</a><a
+class="text-reasonml" href="../api/re/melange/Js/Dict"><code>Js.Dict</code>
+module</a>, with operations like `get`, `set`, etc.
 
 Values of the type `Js.Dict.t` compile to JavaScript objects.
 
@@ -1431,8 +1461,10 @@ let () = clearTimeout(id);
 ```
 
 > **_NOTE:_** The bindings to `setTimeout` and `clearTimeout` are shown here for
-> learning purposes, but they are already available in the
-> [`Js.Global`](../_html/melange/Js/Global) module.
+> learning purposes, but they are already available in the <a class="text-ocaml"
+> href="../api/ml/melange/Js/Global"><code>Js.Global</code> module</a><a
+> class="text-reasonml"
+> href="../api/re/melange/Js/Global"><code>Js.Global</code> module</a>.
 
 Generates:
 


### PR DESCRIPTION
Continuation of #98.

Publishes the API docs for Melange in Reason syntax and updates all links to api modules and functions so that they go to the respective syntax page (`/api/ml` or `/api/re`).

Note the code blocks inside odoc chunks are not converted, see https://github.com/ocaml/odoc/issues/515. Might be something that we can add to odoc in the future.

cc @feihong