### PR TITLE
Latest Melange, OCaml 5, replace `@bs` with `@mel`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - run: python3 -m pip install -r ./pip-requirements.txt
       - uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.14.x
+          ocaml-compiler: ocaml-variants.5.1.0+trunk
           dune-cache: false # can cause trouble when generating melange docs in step below: https://github.com/ocaml/dune/issues/7720
       - name: Install all deps
         run: make install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - deriving-and-optional
     tags-ignore:
       - 'v*'
 
@@ -40,9 +41,9 @@ jobs:
         run: make test
       - name: Build playground
         run: make build-playground
-      - name: Configure Git user
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-      - run: git fetch origin gh-pages --depth=1
-      - run: mike deploy --push unstable
+      # - name: Configure Git user
+      #   run: |
+      #     git config --local user.email "github-actions[bot]@users.noreply.github.com"
+      #     git config --local user.name "github-actions[bot]"
+      # - run: git fetch origin gh-pages --depth=1
+      # - run: mike deploy --push unstable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - deriving-and-optional
     tags-ignore:
       - 'v*'
 
@@ -41,9 +40,9 @@ jobs:
         run: make test
       - name: Build playground
         run: make build-playground
-      # - name: Configure Git user
-      #   run: |
-      #     git config --local user.email "github-actions[bot]@users.noreply.github.com"
-      #     git config --local user.name "github-actions[bot]"
-      # - run: git fetch origin gh-pages --depth=1
-      # - run: mike deploy --push unstable
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - run: git fetch origin gh-pages --depth=1
+      - run: mike deploy --push unstable

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -16,7 +16,7 @@ jobs:
       - run: python3 -m pip install -r ./pip-requirements.txt
       - uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 4.14.x
+          ocaml-compiler: ocaml-variants.5.1.0+trunk
           dune-cache: false # can cause trouble when generating melange docs in step below: https://github.com/ocaml/dune/issues/7720
       - name: Install all deps
         run: make install

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Print this help message
 
 .PHONY: create-switch
 create-switch: ## Create opam switch
-	opam switch create . 4.14.1 -y --deps-only
+	opam switch create . 5.1.0~rc2 -y --deps-only
 
 .PHONY: init
 init: create-switch install ## Configure everything to develop this repository in local

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -383,12 +383,12 @@ Finally, update <code>lib/lib.re</code> to read from the recently added file:
 </div>
 
 ```ocaml
-let dir = [%bs.raw "__dirname"]
+let dir = [%mel.raw "__dirname"]
 let file = "name.txt"
 let name = Node.Fs.readFileSync (dir ^ "/" ^ file) `ascii
 ```
 ```reasonml
-let dir = [%bs.raw "__dirname"];
+let dir = [%mel.raw "__dirname"];
 let file = "name.txt";
 let name = Node.Fs.readFileSync(dir ++ "/" ++ file, `ascii);
 ```

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -2314,7 +2314,7 @@ discarded. The value returned from the operation would not be the addition of
 the two numbers, but rather the inner anonymous callback.
 
 To solve this mismatch between OCaml and JavaScript functions and their
-application, Melange provides a special attribute `@bs` that can be used to
+application, Melange provides a special attribute `@u` that can be used to
 annotate external functions that need to be "uncurried".
 
 <span class="text-reasonml">In Reason syntax, this attribute does not need to be
@@ -2326,16 +2326,16 @@ character `.` to the function type. For example, `(. 'a, 'b) => 'c` instead of
 In the example above:
 
 ```ocaml
-external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@bs]) -> 'c array
+external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@u]) -> 'c array
   = "map"
 ```
 ```reasonml
 external map: (array('a), array('b), (. 'a, 'b) => 'c) => array('c) = "map";
 ```
 
-Here <span class="text-ocaml">`('a -> 'b -> 'c [@bs])`</span><span
+Here <span class="text-ocaml">`('a -> 'b -> 'c [@u])`</span><span
 class="text-reasonml">`(. 'a, 'b) => 'c`</span>will be interpreted as having
-arity 2. In general, <span class="text-ocaml">`'a0 -> 'a1 ...​ 'aN -> 'b0 [@bs]`
+arity 2. In general, <span class="text-ocaml">`'a0 -> 'a1 ...​ 'aN -> 'b0 [@u]`
 is the same as `'a0 -> 'a1 ...​ 'aN -> 'b0`</span><span class="text-reasonml">`.
 'a0, 'a1, ...​ 'aN => 'b0` is the same as `'a0, 'a1, ...​ 'aN => 'b0`</span>
 except the former’s arity is guaranteed to be N while the latter is unknown.
@@ -2359,11 +2359,11 @@ This expression has type int -> int -> int
 but an expression was expected of type ('a -> 'b -> 'c) Js.Fn.arity2
 ```
 
-To solve this, we add <span class="text-ocaml">`@bs`</span><span
+To solve this, we add <span class="text-ocaml">`@u`</span><span
 class="text-reasonml">`.`</span> in the function definition as well:
 
 ```ocaml
-let add = fun [@bs] x y -> x + y
+let add = fun [@u] x y -> x + y
 ```
 ```reasonml
 let add = (. x, y) => x + y;
@@ -2376,7 +2376,7 @@ To work around the verbosity, Melange offers another attribute called
 `mel.uncurry`.
 
 Let’s see how we could use it in the previous example. We just need to replace
-`bs` with `mel.uncurry`:
+`u` with `mel.uncurry`:
 
 ```ocaml
 external map :
@@ -2401,10 +2401,10 @@ let _ = map([||], [||], add);
 
 Everything works fine now, without having to attach any attributes to `add`.
 
-The main difference between `bs` and `mel.uncurry` is that the latter only works
+The main difference between `u` and `mel.uncurry` is that the latter only works
 with externals. `mel.uncurry` is the recommended option to use for bindings,
-while `bs` remains useful for those use cases where performance is crucial and
-we want the JavaScript functions generated from OCaml ones to not be applied
+while `u` remains useful for those use cases where performance is crucial and we
+want the JavaScript functions generated from OCaml ones to not be applied
 partially.
 
 ### Modeling `this`\-based Callbacks

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -1716,7 +1716,11 @@ MyGame.draw(10, 20, undefined);
 ### Calling an object method
 
 If we need to call a JavaScript method, Melange provides the attribute
-`mel.send`:
+`mel.send`.
+
+> In the following snippets, we will be referring to a type `Dom.element`, which
+> is provided within the library `melange.dom`. You can add it to your project
+> by including `(libraries melange.dom)` to your `dune` file:
 
 ```ocaml
 (* Abstract type for the `document` global *)

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -793,11 +793,11 @@ and more:
   external functions](#using-polymorphic-variants-to-bind-to-enums) or [in type
   definitions](#polymorphic-variants)) and [record
   fields](#objects-with-static-shape-record-like).
-- [`bs.deriving`](#generate-getters-setters-and-constructors): generate getters
+- [`deriving`](#generate-getters-setters-and-constructors): generate getters
   and setters for some types
 - [`bs.inline`](#inlining-constant-values): forcefully inline constant values
-- [`bs.optional`](#convert-records-into-abstract-types): omit fields in a record
-  (combines with `bs.deriving`)
+- [`optional`](#convert-records-into-abstract-types): omit fields in a record
+  (combines with `deriving`)
 
 **Extension nodes:**
 
@@ -2540,18 +2540,18 @@ value. It is rarely used, but introduced here for debugging purposes.
 As we saw in a [previous section](#non-shared-data-types), there are some types
 in Melange that compile to values that are not easy to manipulate from
 JavaScript. To facilitate the communication from JavaScript code with values of
-these types, Melange includes an attribute `bs.deriving` that helps generating
+these types, Melange includes an attribute `deriving` that helps generating
 conversion functions, as well as functions to create values from these types. In
 particular, for variants and polymorphic variants.
 
-Additionally, `bs.deriving` can be used with record types, to generate setters
+Additionally, `deriving` can be used with record types, to generate setters
 and getters as well as creation functions.
 
 ### Variants
 
 #### Creating values
 
-Use `@bs.deriving accessors` on a variant type to create constructor values for
+Use `@deriving accessors` on a variant type to create constructor values for
 each branch.
 
 ```ocaml
@@ -2559,10 +2559,10 @@ type action =
   | Click
   | Submit of string
   | Cancel
-[@@bs.deriving accessors]
+[@@deriving accessors]
 ```
 ```reasonml
-[@bs.deriving accessors]
+[@deriving accessors]
 type action =
   | Click
   | Submit(string)
@@ -2577,7 +2577,7 @@ follows:
 - For variant tags without payloads, it will be a constant with the runtime
   value of the tag.
 
-Given the `action` type definition above, annotated with `bs.deriving`, Melange
+Given the `action` type definition above, annotated with `deriving`, Melange
 will generate something similar to the following code:
 
 ```ocaml
@@ -2628,11 +2628,11 @@ const click = generators.click;
 
 #### Conversion functions
 
-Use `@bs.deriving jsConverter` on a variant type to create converter functions
+Use `@deriving jsConverter` on a variant type to create converter functions
 that allow to transform back and forth between JavaScript integers and Melange
 variant values.
 
-There are a few differences with `@bs.deriving accessors`:
+There are a few differences with `@deriving accessors`:
 
 - `jsConverter` works with the `bs.as` attribute, while `accessors` does not
 - `jsConverter` does not support variant tags with payload, while `accessors`
@@ -2648,10 +2648,10 @@ type action =
   | Click
   | Submit [@bs.as 3]
   | Cancel
-[@@bs.deriving jsConverter]
+[@@deriving jsConverter]
 ```
 ```reasonml
-[@bs.deriving jsConverter]
+[@deriving jsConverter]
 type action =
   | Click
   | [@bs.as 3] Submit
@@ -2682,18 +2682,18 @@ be converted into a variant tag of the `action` type.
 ##### Hide runtime types
 
 For extra type safety, we can hide the runtime representation of variants
-(`int`) from the generated functions, by using `{ jsConverter = newType }`
-payload with `@bs.deriving`:
+(`int`) from the generated functions, by using `jsConverter {  newType }`
+payload with `@deriving`:
 
 ```ocaml
 type action =
   | Click
   | Submit [@bs.as 3]
   | Cancel
-[@@bs.deriving { jsConverter = newType }]
+[@@deriving jsConverter {  newType }]
 ```
 ```reasonml
-[@bs.deriving {jsConverter: newType}]
+[@deriving jsConverter({newType: newType})]
 type action =
   | Click
   | [@bs.as 3] Submit
@@ -2720,10 +2720,10 @@ way to create an `abs_action` is by calling the `actionToJs` function.
 
 ### Polymorphic variants
 
-The `@bs.deriving jsConverter` attribute is applicable to polymorphic variants
+The `@deriving jsConverter` attribute is applicable to polymorphic variants
 as well.
 
-> **_NOTE:_** Similarly to variants, the `@bs.deriving jsConverter` attribute
+> **_NOTE:_** Similarly to variants, the `@deriving jsConverter` attribute
 > cannot be used when the polymorphic variant tags have payloads. Refer to the
 > [section on runtime representation](#data-types-and-runtime-representation) to
 > learn more about how polymorphic variants are represented in JavaScript.
@@ -2736,10 +2736,10 @@ type action =
   | `Submit [@bs.as "submit"]
   | `Cancel
   ]
-[@@bs.deriving jsConverter]
+[@@deriving jsConverter]
 ```
 ```reasonml
-[@bs.deriving jsConverter]
+[@deriving jsConverter]
 type action = [ | `Click | [@bs.as "submit"] `Submit | `Cancel];
 ```
 
@@ -2756,25 +2756,25 @@ external actionToJs: action => string = ;
 external actionFromJs: string => option(action) = ;
 ```
 
-The `{ jsConverter = newType }` payload can also be used with polymorphic
+The `jsConverter {  newType }` payload can also be used with polymorphic
 variants.
 
 ### Records
 
 #### Accessing fields
 
-Use `@bs.deriving accessors` on a record type to create accessor functions for
+Use `@deriving accessors` on a record type to create accessor functions for
 its record field names.
 
 ```ocaml
-type pet = { name : string } [@@bs.deriving accessors]
+type pet = { name : string } [@@deriving accessors]
 
 let pets = [| { name = "Brutus" }; { name = "Mochi" } |]
 
 let () = pets |. Belt.Array.map name |. Js.Array2.joinWith "&" |. Js.log
 ```
 ```reasonml
-[@bs.deriving accessors]
+[@deriving accessors]
 type pet = {name: string};
 
 let pets = [|{name: "Brutus"}, {name: "Mochi"}|];
@@ -2842,14 +2842,14 @@ An example of this use-case would be expecting `{ name = "John"; age = None }`
 to generate a JavaScript such as `{name: "Carl"}`, where the `age` key doesn’t
 appear.
 
-The `@bs.deriving abstract` attribute exists to solve this problem. When present
-in a record type, `@bs.deriving abstract` makes the record definition abstract
+The `@deriving abstract` attribute exists to solve this problem. When present
+in a record type, `@deriving abstract` makes the record definition abstract
 and generates the following functions instead:
 
 - A constructor function for creating values of the type
 - Getters and setters for accessing the record fields
 
-`@bs.deriving abstract` effectively models a record-shaped JavaScript object
+`@deriving abstract` effectively models a record-shaped JavaScript object
 exclusively through a set of (generated) functions derived from attribute
 annotations on the OCaml type definition.
 
@@ -2971,20 +2971,20 @@ var bob = bob.name;
 The functions are named by appending `Get` to the field names of the record to
 prevent potential clashes with other values within the module. If shorter names
 are preferred for the getter functions, there is an alternate `{ abstract =
-light }` payload that can be passed to `bs.deriving`:
+light }` payload that can be passed to `deriving`:
 
 ```ocaml
 type person = {
   name : string;
   age : int;
 }
-[@@bs.deriving { abstract = light }]
+[@@deriving { abstract = light }]
 
 let alice = person ~name:"Alice" ~age:20
 let aliceName = name alice
 ```
 ```reasonml
-[@bs.deriving {abstract: light}]
+[@deriving {abstract: light}]
 type person = {
   name: string,
   age: int,
@@ -3011,16 +3011,16 @@ function no longer requires the final `unit` argument since we have excluded the
 optional field in this case.
 
 > **_NOTE:_** The `bs.as` attribute can still be applied to record fields when
-> the record type is annotated with `bs.deriving`, allowing for the renaming of
+> the record type is annotated with `deriving`, allowing for the renaming of
 > fields in the resulting JavaScript objects, as demonstrated in the section
 > about [binding to objects with static
 > shape](#objects-with-static-shape-record-like). However, the option to pass
 > indices to the `bs.as` decorator (like `[@bs.as "0"]`) to change the runtime
-> representation to an array is not available when using `bs.deriving`.
+> representation to an array is not available when using `deriving`.
 
 ##### Compatibility with OCaml features
 
-The `@bs.deriving abstract` attribute and its lightweight variant can be used
+The `@deriving abstract` attribute and its lightweight variant can be used
 with [mutable
 fields](https://v2.ocaml.org/manual/coreexamples.html#s:imperative-features) and
 [private types](https://v2.ocaml.org/manual/privatetypes.html), which are
@@ -3034,14 +3034,14 @@ type person = {
   name : string;
   mutable age : int;
 }
-[@@bs.deriving abstract]
+[@@deriving abstract]
 
 let alice = person ~name:"Alice" ~age:20
 
 let () = ageSet alice 21
 ```
 ```reasonml
-[@bs.deriving abstract]
+[@deriving abstract]
 type person = {
   name: string,
   mutable age: int,
@@ -3075,10 +3075,10 @@ type person = private {
   name : string;
   age : int;
 }
-[@@bs.deriving abstract]
+[@@deriving abstract]
 ```
 ```reasonml
-[@bs.deriving abstract]
+[@deriving abstract]
 type person =
   pri {
     name: string,

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -2062,18 +2062,18 @@ type style
 
 external document : document = "document" [@@bs.val]
 external get_by_id : document -> string -> Dom.element = "getElementById"
-  [@@bs.send]
+[@@mel.send]
 external style : Dom.element -> style = "style" [@@bs.get]
 external transition_timing_function :
   style ->
-  [ `ease
-  | `easeIn [@bs.as "ease-in"]
-  | `easeOut [@bs.as "ease-out"]
-  | `easeInOut [@bs.as "ease-in-out"]
-  | `linear
-  ] ->
+  ([ `ease
+   | `easeIn [@mel.as "ease-in"]
+   | `easeOut [@mel.as "ease-out"]
+   | `easeInOut [@mel.as "ease-in-out"]
+   | `linear ]
+  [@mel.string]) ->
   unit = "transitionTimingFunction"
-  [@@bs.set]
+[@@mel.set]
 
 let element_style = style (get_by_id document "my-id")
 let () = transition_timing_function element_style `easeIn
@@ -2083,18 +2083,18 @@ type document;
 type style;
 
 [@bs.val] external document: document = "document";
-[@bs.send]
+[@mel.send]
 external get_by_id: (document, string) => Dom.element = "getElementById";
 [@bs.get] external style: Dom.element => style = "style";
-[@bs.set]
+[@mel.set]
 external transition_timing_function:
   (
     style,
-    [
+    [@mel.string] [
       | `ease
-      | [@bs.as "ease-in"] `easeIn
-      | [@bs.as "ease-out"] `easeOut
-      | [@bs.as "ease-in-out"] `easeInOut
+      | [@mel.as "ease-in"] `easeIn
+      | [@mel.as "ease-out"] `easeOut
+      | [@mel.as "ease-in-out"] `easeInOut
       | `linear
     ]
   ) =>

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -1345,8 +1345,8 @@ notation `[]`:
 ```ocaml
 type t
 external create : int -> t = "Int32Array" [@@mel.new]
-external get : t -> int -> int = "get" [@@mel.get_index]
-external set : t -> int -> int -> unit = "set" [@@mel.set_index]
+external get : t -> int -> int = "" [@@mel.get_index]
+external set : t -> int -> int -> unit = "" [@@mel.set_index]
 
 let () =
   let i32arr = (create 3) in
@@ -1356,8 +1356,8 @@ let () =
 ```reasonml
 type t;
 [@mel.new] external create: int => t = "Int32Array";
-[@mel.get_index] external get: (t, int) => int = "get";
-[@mel.set_index] external set: (t, int, int) => unit = "set";
+[@mel.get_index] external get: (t, int) => int;
+[@mel.set_index] external set: (t, int, int) => unit;
 
 let () = {
   let i32arr = create(3);
@@ -2968,13 +2968,13 @@ type person = {
   name : string;
   age : int;
 }
-[@@deriving { abstract = light }]
+[@@deriving abstract { light }]
 
 let alice = person ~name:"Alice" ~age:20
 let aliceName = name alice
 ```
 ```reasonml
-[@deriving {abstract: light}]
+[@deriving abstract({light: light})]
 type person = {
   name: string,
   age: int,

--- a/docs/communicate-with-javascript.md
+++ b/docs/communicate-with-javascript.md
@@ -55,12 +55,12 @@ An example where Melange uses extension nodes to communicate with JavaScript is
 to produce "raw" JavaScript inside a Melange program:
 
 ```ocaml
-[%%bs.raw "var a = 1; var b = 2"]
-let add = [%bs.raw "a + b"]
+[%%mel.raw "var a = 1; var b = 2"]
+let add = [%mel.raw "a + b"]
 ```
 ```reasonml
-[%%bs.raw "var a = 1; var b = 2"];
-let add = [%bs.raw "a + b"];
+[%%mel.raw "var a = 1; var b = 2"];
+let add = [%mel.raw "a + b"];
 ```
 
 Which will generate the following JavaScript code:
@@ -120,10 +120,10 @@ Melange as well.
 ##### Defining new attributes
 
 The second approach is introducing new attributes specifically designed for
-Melange, such as the [`bs.val`
-attribute](#bind-to-global-javascript-functions-or-values) used to bind to
-global JavaScript values. The complete list of attributes introduced by Melange
-can be found [here](#list-of-attributes-and-extension-nodes).
+Melange, such as the [`mel.set` attribute](#bind-to-object-properties) used to
+bind to properties of JavaScript objects. The complete list of attributes
+introduced by Melange can be found
+[here](#list-of-attributes-and-extension-nodes).
 
 Attribute annotations can use one, two or three `@` characters depending on
 their placement in the code and which kind of syntax tree node they are
@@ -131,24 +131,25 @@ annotating. More information about attributes can be found in the [dedicated
 OCaml manual page](https://v2.ocaml.org/manual/attributes.html).
 
 Here are some samples using Melange attributes
-[`bs.val`](#bind-to-global-javascript-functions-or-values) and
-[`bs.as`](#using-ocaml-records):
+[`mel.set`](#bind-to-object-properties) and [`mel.as`](#using-ocaml-records):
 
 ```ocaml
-external clearTimeout : timeoutId -> unit = "clearTimeout" [@@bs.val]
+type document
+external setTitleDom : document -> string -> unit = "title" [@@mel.set]
 
 type t = {
-  age : int; [@bs.as "a"]
-  name : string; [@bs.as "n"]
+  age : int; [@mel.as "a"]
+  name : string; [@mel.as "n"]
 }
 ```
 ```reasonml
-[@bs.val] external clearTimeout: timeoutId => unit = "clearTimeout";
+type document;
+[@mel.set] external setTitleDom: (document, string) => unit = "title";
 
 type t = {
-  [@bs.as "a"]
+  [@mel.as "a"]
   age: int,
-  [@bs.as "n"]
+  [@mel.as "n"]
   name: string,
 };
 ```
@@ -179,16 +180,19 @@ it usually refers to a C function with that name. For Melange, it refers to the
 functions or values that exist in the runtime JavaScript code, and will be used
 from Melange.
 
-Melange externals are always decorated with certain `[@bs.xxx]` attributes. Each
-one of the [available attributes](#list-of-attributes-and-extension-nodes) will
-be further explained in the next sections.
+In Melange, externals can be used to [binding to global JavaScript
+objects](#bind-to-global-javascript-functions-or-values). They can also be
+decorated with certain `[@mel.xxx]` attributes to facilitate the creation of
+bindings in specific scenarios. Each one of the [available
+attributes](#list-of-attributes-and-extension-nodes) will be further explained
+in the next sections.
 
 Once declared, one can use an `external` as a normal value. Melange external
 functions are turned into the expected JavaScript values, inlined into their
 callers during compilation, and completely erased afterwards. They don’t appear
 in the JavaScript output, so there are no costs on bundling size.
 
-**Note**: it is recommended to use external functions and the `[@bs.xxx]`
+**Note**: it is recommended to use external functions and the `[@mel.xxx]`
 attributes in the interface files as well, as this allows some optimizations
 where the resulting JavaScript values can be directly inlined at the call sites.
 
@@ -238,19 +242,19 @@ properties. Consider the following example:
 ```ocaml
 type document
 
-external document : document = "document" [@@bs.val]
-external set_title : document -> string -> unit = "title" [@@bs.set]
+external document : document = "document"
+external set_title : document -> string -> unit = "title" [@@mel.set]
 ```
 ```reasonml
 type document;
 
-[@bs.val] external document: document = "document";
-[@bs.set] external set_title: (document, string) => unit = "title";
+external document: document = "document";
+[@mel.set] external set_title: (document, string) => unit = "title";
 ```
 
-Subsequent sections delve into the details of the
-[`bs.val`](#bind-to-global-javascript-functions-or-values) and
-[`bs.set`](#bind-to-object-properties) attributes.
+Subsequent sections delve into the details about the
+[`mel.set`](#bind-to-object-properties) attribute and [how to bind to global
+values](#bind-to-global-javascript-functions-or-values) like `document`. s.
 
 For a comprehensive understanding of abstract types and their usefulness, refer
 to the "Encapsulation" section of the [OCaml Cornell
@@ -687,16 +691,16 @@ can be found in [the section below](#bind-to-js-object).
 
 #### Regular expressions
 
-Regular expressions created using the `%bs.re` extension node compile to their
+Regular expressions created using the `%mel.re` extension node compile to their
 JavaScript counterpart.
 
 For example:
 
 ```ocaml
-let r = [%bs.re "/b/g"]
+let r = [%mel.re "/b/g"]
 ```
 ```reasonml
-let r = [%bs.re "/b/g"];
+let r = [%mel.re "/b/g"];
 ```
 
 Will compile to:
@@ -738,64 +742,60 @@ them before doing so.
 
 ## List of attributes and extension nodes
 
-> **_NOTE:_** All these attributes and extension nodes are prefixed with `bs.`
-> for backwards compatibility. They will be updated to `mel.` in the future.
-
 **Attributes:**
 
 These attributes are used to annotate `external` definitions:
 
-- [`bs.get`](#bind-to-object-properties): read JavaScript object properties
+- [`mel.get`](#bind-to-object-properties): read JavaScript object properties
   statically by name, using the dot notation `.`
-- [`bs.get_index`](#bind-to-object-properties): read a JavaScript object’s
+- [`mel.get_index`](#bind-to-object-properties): read a JavaScript object’s
   properties dynamically by using the bracket notation `[]`
-- [`bs.module`](#using-functions-from-other-javascript-modules): bind to a value
-  from a JavaScript module
-- [`bs.new`](#javascript-classes): bind to a JavaScript class constructor
-- [`bs.obj`](#using-external-functions): create a JavaScript object
-- [`bs.return`](#wrapping-returned-nullable-values): automate conversion from
+- [`mel.module`](#using-functions-from-other-javascript-modules): bind to a
+  value from a JavaScript module
+- [`mel.new`](#javascript-classes): bind to a JavaScript class constructor
+- [`mel.obj`](#using-external-functions): create a JavaScript object
+- [`mel.return`](#wrapping-returned-nullable-values): automate conversion from
   nullable values to `Option.t` values
-- [`bs.send`](#calling-an-object-method): call a JavaScript object method using
+- [`mel.send`](#calling-an-object-method): call a JavaScript object method using
   [pipe first](#pipe-first) convention
-- [`bs.send.pipe`](#calling-an-object-method): call a JavaScript object method
+- [`mel.send.pipe`](#calling-an-object-method): call a JavaScript object method
   using [pipe last](#pipe-last) convention
-- [`bs.set`](#bind-to-object-properties): set JavaScript object properties
+- [`mel.set`](#bind-to-object-properties): set JavaScript object properties
   statically by name, using the dot notation `.`
-- [`bs.set_index`](#bind-to-object-properties): set JavaScript object properties
-  dynamically by using the bracket notation `[]`
-- [`bs.scope`](#binding-to-properties-inside-a-module-or-global): reach to
+- [`mel.set_index`](#bind-to-object-properties): set JavaScript object
+  properties dynamically by using the bracket notation `[]`
+- [`mel.scope`](#binding-to-properties-inside-a-module-or-global): reach to
   deeper properties inside a JavaScript object
-- [`bs.splice`](#variadic-function-arguments): a deprecated attribute, is an
-  alternate form of `bs.variadic`
-- [`bs.val`](#bind-to-global-javascript-functions-or-values): bind to global
-  JavaScript functions or other values
-- [`bs.variadic`](#variadic-function-arguments): bind to a function taking
+- [`mel.splice`](#variadic-function-arguments): a deprecated attribute, is an
+  alternate form of `mel.variadic`
+- [`mel.variadic`](#variadic-function-arguments): bind to a function taking
   variadic arguments from an array
 
 These attributes are used to annotate arguments in `external` definitions:
 
-- [`bs`](#binding-to-callbacks): define function arguments as uncurried (manual)
-- [`bs.int`](#using-polymorphic-variants-to-bind-to-enums): compile function
+- [`u`](#binding-to-callbacks): define function arguments as uncurried (manual)
+- [`mel.int`](#using-polymorphic-variants-to-bind-to-enums): compile function
   argument to an int
-- [`bs.string`](#using-polymorphic-variants-to-bind-to-enums): compile function
+- [`mel.string`](#using-polymorphic-variants-to-bind-to-enums): compile function
   argument to a string
-- [`bs.this`](#modeling-this-based-callbacks): bind to `this` based callbacks
-- [`bs.uncurry`](#binding-to-callbacks): define function arguments as uncurried
+- [`mel.this`](#modeling-this-based-callbacks): bind to `this` based callbacks
+- [`mel.uncurry`](#binding-to-callbacks): define function arguments as uncurried
   (automated)
-- [`bs.unwrap`](#approach-2-polymorphic-variant-bsunwrap): unwrap variant values
+- [`mel.unwrap`](#approach-2-polymorphic-variant-bsunwrap): unwrap variant
+  values
 
 These attributes are used in places like records, fields, arguments, functions,
 and more:
 
-- `bs.as`: redefine the name generated in the JavaScript output code. Used in
+- `mel.as`: redefine the name generated in the JavaScript output code. Used in
   [constant function arguments](#constant-values-as-arguments),
   [variants](#conversion-functions), polymorphic variants (either [inlined in
   external functions](#using-polymorphic-variants-to-bind-to-enums) or [in type
   definitions](#polymorphic-variants)) and [record
   fields](#objects-with-static-shape-record-like).
-- [`deriving`](#generate-getters-setters-and-constructors): generate getters
-  and setters for some types
-- [`bs.inline`](#inlining-constant-values): forcefully inline constant values
+- [`deriving`](#generate-getters-setters-and-constructors): generate getters and
+  setters for some types
+- [`mel.inline`](#inlining-constant-values): forcefully inline constant values
 - [`optional`](#convert-records-into-abstract-types): omit fields in a record
   (combines with `deriving`)
 
@@ -817,22 +817,22 @@ The same field `preprocess` can be added to `melange.emit`.
 
 Here is the list of all the extension nodes supported by Melange:
 
-- [`bs.debugger`](#debugger): insert `debugger` statements
-- [`bs.external`](#detect-global-variables): read global values
-- [`bs.obj`](#using-jst-objects): create JavaScript object literals
-- [`bs.raw`](#generate-raw-javascript): write raw JavaScript code
-- [`bs.re`](#regular-expressions): insert regular expressions
+- [`mel.debugger`](#debugger): insert `debugger` statements
+- [`mel.external`](#detect-global-variables): read global values
+- [`mel.obj`](#using-jst-objects): create JavaScript object literals
+- [`mel.raw`](#generate-raw-javascript): write raw JavaScript code
+- [`mel.re`](#regular-expressions): insert regular expressions
 
 ## Generate raw JavaScript
 
 It is possible to directly write JavaScript code from a Melange file. This is
 unsafe, but it can be useful for prototyping or as an escape hatch.
 
-To do it, we will use the `bs.raw`
+To do it, we will use the `mel.raw`
 [extension](https://v2.ocaml.org/manual/extensionnodes.html):
 
 ```ocaml
-let add = [%bs.raw {|
+let add = [%mel.raw {|
   function(a, b) {
     console.log("hello from raw JavaScript!");
     return a + b;
@@ -842,7 +842,7 @@ let add = [%bs.raw {|
 let () = Js.log (add 1 2)
 ```
 ```reasonml
-let add = [%bs.raw
+let add = [%mel.raw
   {|
   function(a, b) {
     console.log("hello from raw JavaScript!");
@@ -861,46 +861,46 @@ there is no need to escape characters inside the string.
 
 Using <span class="text-ocaml">one percentage sign</span><span
 class="text-reasonml">the extension name between square brackets</span>
-(`[%bs.raw <string>]`) is useful to define expressions (function bodies, or
+(`[%mel.raw <string>]`) is useful to define expressions (function bodies, or
 other values) where the implementation is directly JavaScript. This is useful as
 we can attach the type signature already in the same line, to make our code
 safer. For example:
 
 ```ocaml
-let f : unit -> int = [%bs.raw "function() {return 1}"]
+let f : unit -> int = [%mel.raw "function() {return 1}"]
 ```
 ```reasonml
-let f: unit => int = ([%bs.raw "function() {return 1}"]: unit => int);
+let f: unit => int = ([%mel.raw "function() {return 1}"]: unit => int);
 ```
 
-Using <span class="text-ocaml">two percentage signs (`[%%bs.raw
+Using <span class="text-ocaml">two percentage signs (`[%%mel.raw
 <string>]`)</span><span class="text-reasonml">the extension name without square
-brackets (`%bs.raw <string>`)</span> is reserved for definitions in a
+brackets (`%mel.raw <string>`)</span> is reserved for definitions in a
 [structure](https://v2.ocaml.org/manual/moduleexamples.html#s:module:structures)
 or [signature](https://v2.ocaml.org/manual/moduleexamples.html#s%3Asignature).
 
 For example:
 
 ```ocaml
-[%%bs.raw "var a = 1"]
+[%%mel.raw "var a = 1"]
 ```
 ```reasonml
-[%%bs.raw "var a = 1"];
+[%%mel.raw "var a = 1"];
 ```
 
 ## Debugger
 
-Melange allows you to inject a `debugger;` expression using the `bs.debugger`
+Melange allows you to inject a `debugger;` expression using the `mel.debugger`
 extension:
 
 ```ocaml
 let f x y =
-  [%bs.debugger];
+  [%mel.debugger];
   x + y
 ```
 ```reasonml
 let f = (x, y) => {
-  [%bs.debugger];
+  [%mel.debugger];
   x + y;
 };
 ```
@@ -917,21 +917,21 @@ function f (x,y) {
 ## Detect global variables
 
 Melange provides a relatively type safe approach to use globals that might be
-defined either in the JavaScript runtime environment: `bs.external`.
+defined either in the JavaScript runtime environment: `mel.external`.
 
-`[%bs.external id]` will check if the JavaScript value `id` is `undefined` or
+`[%mel.external id]` will check if the JavaScript value `id` is `undefined` or
 not, and return an `Option.t` value accordingly.
 
 For example:
 
 ```ocaml
-let () = match [%bs.external __DEV__] with
+let () = match [%mel.external __DEV__] with
 | Some _ -> Js.log "dev mode"
 | None -> Js.log "production mode"
 ```
 ```reasonml
 let () =
-  switch ([%bs.external __DEV__]) {
+  switch ([%mel.external __DEV__]) {
   | Some(_) => Js.log("dev mode")
   | None => Js.log("production mode")
   };
@@ -940,13 +940,13 @@ let () =
 Another example:
 
 ```ocaml
-let () = match [%bs.external __filename] with
+let () = match [%mel.external __filename] with
 | Some f -> Js.log f
 | None -> Js.log "non-node environment"
 ```
 ```reasonml
 let () =
-  switch ([%bs.external __filename]) {
+  switch ([%mel.external __filename]) {
   | Some(f) => Js.log(f)
   | None => Js.log("non-node environment")
   };
@@ -974,21 +974,20 @@ if ("development" !== "production") {
 In this case, bundlers such as Webpack can tell that the `if` statement always
 evaluates to a specific branch and eliminate the others.
 
-Melange provides the `bs.inline` attribute to achieve the same goal in generated
-JavaScript. Let’s look at an example:
+Melange provides the `mel.inline` attribute to achieve the same goal in
+generated JavaScript. Let’s look at an example:
 
 ```ocaml
-external node_env : string = "NODE_ENV" [@@bs.val] [@@bs.scope "process", "env"]
+external node_env : string = "NODE_ENV" [@@mel.scope "process", "env"]
 
 let development = "development"
 let () = if node_env <> development then Js.log "Only in Production"
 
-let development_inline = "development" [@@bs.inline]
+let development_inline = "development" [@@mel.inline]
 let () = if node_env <> development_inline then Js.log "Only in Production"
 ```
 ```reasonml
-[@bs.val] [@bs.scope ("process", "env")]
-external node_env: string = "NODE_ENV";
+[@mel.scope ("process", "env")] external node_env: string = "NODE_ENV";
 
 let development = "development";
 let () =
@@ -996,7 +995,7 @@ let () =
     Js.log("Only in Production");
   };
 
-[@bs.inline]
+[@mel.inline]
 let development_inline = "development";
 let () =
   if (node_env != development_inline) {
@@ -1059,7 +1058,7 @@ type person = {
   age : int;
 }
 
-external john : person = "john" [@@bs.module "MySchool"]
+external john : person = "john" [@@mel.module "MySchool"]
 let john_name = john.name
 ```
 ```reasonml
@@ -1069,7 +1068,7 @@ type person = {
   age: int,
 };
 
-[@bs.module "MySchool"] external john: person = "john";
+[@mel.module "MySchool"] external john: person = "john";
 let john_name = john.name;
 ```
 
@@ -1082,22 +1081,22 @@ var john_name = MySchool.john.name;
 ```
 
 External functions are documented in [a previous section](#external-functions).
-The `bs.module` attribute is documented
+The `mel.module` attribute is documented
 [here](#using-functions-from-other-javascript-modules).
 
 If you want or need to use different field names on the Melange and the
-JavaScript sides, you can use the `bs.as` decorator:
+JavaScript sides, you can use the `mel.as` decorator:
 
 ```ocaml
 type action = {
-  type_ : string [@bs.as "type"]
+  type_ : string [@mel.as "type"]
 }
 
 let action = { type_ = "ADD_USER" }
 ```
 ```reasonml
 type action = {
-  [@bs.as "type"]
+  [@mel.as "type"]
   type_: string,
 };
 
@@ -1117,21 +1116,21 @@ Melange, for example, where the JavaScript name we want to generate is a
 [reserved keyword](https://v2.ocaml.org/manual/lex.html#sss:keywords).
 
 It is also possible to map a Melange record to a JavaScript array by passing
-indices to the `bs.as` decorator:
+indices to the `mel.as` decorator:
 
 ```ocaml
 type t = {
-  foo : int; [@bs.as "0"]
-  bar : string; [@bs.as "1"]
+  foo : int; [@mel.as "0"]
+  bar : string; [@mel.as "1"]
 }
 
 let value = { foo = 7; bar = "baz" }
 ```
 ```reasonml
 type t = {
-  [@bs.as "0"]
+  [@mel.as "0"]
   foo: int,
-  [@bs.as "1"]
+  [@mel.as "1"]
   bar: string,
 };
 
@@ -1158,11 +1157,11 @@ advance, which can be helpful for prototyping or quickly generating JavaScript
 object literals.
 
 Melange provides some ways to create `Js.t` object values, as well as accessing
-the properties inside them. To create values, the `[%bs.obj]` extension is used,
-and the `##` infix operator allows to read from the object properties:
+the properties inside them. To create values, the `[%mel.obj]` extension is
+used, and the `##` infix operator allows to read from the object properties:
 
 ```ocaml
-let john = [%bs.obj { name = "john"; age = 99 }]
+let john = [%mel.obj { name = "john"; age = 99 }]
 let t = john##name
 ```
 ```reasonml
@@ -1193,8 +1192,8 @@ types that include a field `name` that is of type string, e.g.:
 ```ocaml
 let name_extended obj = obj##name ^ " wayne"
 
-let one = name_extended [%bs.obj { name = "john"; age = 99 }]
-let two = name_extended [%bs.obj { name = "jane"; address = "1 infinite loop" }]
+let one = name_extended [%mel.obj { name = "john"; age = 99 }]
+let two = name_extended [%mel.obj { name = "jane"; address = "1 infinite loop" }]
 ```
 ```reasonml
 let name_extended = obj => obj##name ++ " wayne";
@@ -1210,9 +1209,9 @@ manual](https://v2.ocaml.org/manual/objectexamples.html).
 #### Using external functions
 
 We have already explored one approach for creating JavaScript object literals by
-using [`Js.t` values and the `bs.obj` extension](#using-jst-objects).
+using [`Js.t` values and the `mel.obj` extension](#using-jst-objects).
 
-Melange additionally offers the `bs.obj` attribute, which can be used in
+Melange additionally offers the `mel.obj` attribute, which can be used in
 combination with external functions to create JavaScript objects. When these
 functions are called, they generate objects with fields corresponding to the
 labeled arguments of the function.
@@ -1244,10 +1243,10 @@ external route :
   ?options:< .. > ->
   unit ->
   _ = ""
-  [@@bs.obj]
+  [@@mel.obj]
 ```
 ```reasonml
-[@bs.obj]
+[@mel.obj]
 external route:
   (
     ~_type: string,
@@ -1276,8 +1275,8 @@ In the route function, the `_type` argument starts with an underscore. When
 binding to JavaScript objects with fields that are reserved keywords in OCaml,
 Melange allows the use of an underscore prefix for the labeled arguments. The
 resulting JavaScript object will have the underscore removed from the field
-names. This is only required for the `bs.obj` attribute, while for other cases,
-the `bs.as` attribute can be used to rename fields.
+names. This is only required for the `mel.obj` attribute, while for other cases,
+the `mel.as` attribute can be used to rename fields.
 
 If we call the function like this:
 
@@ -1305,16 +1304,16 @@ var homeRoute = {
 #### Bind to object properties
 
 If you need to bind only to the property of a JavaScript object, you can use
-`bs.get` and `bs.set` to access it using the dot notation `.`:
+`mel.get` and `mel.set` to access it using the dot notation `.`:
 
 ```ocaml
 (* Abstract type for the `document` value *)
 type document
 
-external document : document = "document" [@@bs.val]
+external document : document = "document"
 
-external set_title : document -> string -> unit = "title" [@@bs.set]
-external get_title : document -> string = "title" [@@bs.get]
+external set_title : document -> string -> unit = "title" [@@mel.set]
+external get_title : document -> string = "title" [@@mel.get]
 
 let current = get_title document
 let () = set_title document "melange"
@@ -1323,10 +1322,10 @@ let () = set_title document "melange"
 /* Abstract type for the `document` value */
 type document;
 
-[@bs.val] external document: document = "document";
+external document: document = "document";
 
-[@bs.set] external set_title: (document, string) => unit = "title";
-[@bs.get] external get_title: document => string = "title";
+[@mel.set] external set_title: (document, string) => unit = "title";
+[@mel.get] external get_title: document => string = "title";
 
 let current = get_title(document);
 let () = set_title(document, "melange");
@@ -1340,14 +1339,14 @@ document.title = "melange";
 ```
 
 Alternatively, if some dynamism is required on the way the property is accessed,
-you can use `bs.get_index` and `bs.set_index` to access it using the bracket
+you can use `mel.get_index` and `mel.set_index` to access it using the bracket
 notation `[]`:
 
 ```ocaml
 type t
-external create : int -> t = "Int32Array" [@@bs.new]
-external get : t -> int -> int = "get" [@@bs.get_index]
-external set : t -> int -> int -> unit = "set" [@@bs.set_index]
+external create : int -> t = "Int32Array" [@@mel.new]
+external get : t -> int -> int = "get" [@@mel.get_index]
+external set : t -> int -> int -> unit = "set" [@@mel.set_index]
 
 let () =
   let i32arr = (create 3) in
@@ -1356,9 +1355,9 @@ let () =
 ```
 ```reasonml
 type t;
-[@bs.new] external create: int => t = "Int32Array";
-[@bs.get_index] external get: (t, int) => int = "get";
-[@bs.set_index] external set: (t, int, int) => unit = "set";
+[@mel.new] external create: int => t = "Int32Array";
+[@mel.get_index] external get: (t, int) => int = "get";
+[@mel.set_index] external set: (t, int, int) => unit = "set";
 
 let () = {
   let i32arr = create(3);
@@ -1394,16 +1393,16 @@ Values of the type `Js.Dict.t` compile to JavaScript objects.
 ### JavaScript classes
 
 JavaScript classes are special kinds of objects. To interact with classes,
-Melange exposes `bs.new` to emulate e.g. `new Date()`:
+Melange exposes `mel.new` to emulate e.g. `new Date()`:
 
 ```ocaml
 type t
-external create_date : unit -> t = "Date" [@@bs.new]
+external create_date : unit -> t = "Date" [@@mel.new]
 let date = create_date ()
 ```
 ```reasonml
 type t;
-[@bs.new] external create_date: unit => t = "Date";
+[@mel.new] external create_date: unit => t = "Date";
 let date = create_date();
 ```
 
@@ -1413,17 +1412,17 @@ Which generates:
 var date = new Date();
 ```
 
-You can chain `bs.new` and `bs.module` if the JavaScript class you want to work
-with is in a separate JavaScript module:
+You can chain `mel.new` and `mel.module` if the JavaScript class you want to
+work with is in a separate JavaScript module:
 
 ```ocaml
 type t
-external book : unit -> t = "Book" [@@bs.new] [@@bs.module]
+external book : unit -> t = "Book" [@@mel.new] [@@mel.module]
 let myBook = book ()
 ```
 ```reasonml
 type t;
-[@bs.new] [@bs.module] external book: unit => t = "Book";
+[@mel.new] [@mel.module] external book: unit => t = "Book";
 let myBook = book();
 ```
 
@@ -1436,16 +1435,14 @@ var myBook = new Book();
 
 ## Bind to global JavaScript functions or values
 
-Binding to a JavaScript function makes use of `external`, like with objects. If
-we want to bind to a function available globally, Melange offers the `bs.val`
-attribute:
+Binding to a JavaScript function available globally makes use of `external`,
+like with objects. But unlike objects, there is no need to add any attributes:
 
 ```ocaml
 (* Abstract type for `timeoutId` *)
 type timeoutId
 external setTimeout : (unit -> unit) -> int -> timeoutId = "setTimeout"
-  [@@bs.val]
-external clearTimeout : timeoutId -> unit = "clearTimeout" [@@bs.val]
+external clearTimeout : timeoutId -> unit = "clearTimeout"
 
 let id = setTimeout (fun () -> Js.log "hello") 100
 let () = clearTimeout id
@@ -1453,8 +1450,8 @@ let () = clearTimeout id
 ```reasonml
 /* Abstract type for `timeoutId` */
 type timeoutId;
-[@bs.val] external setTimeout: (unit => unit, int) => timeoutId = "setTimeout";
-[@bs.val] external clearTimeout: timeoutId => unit = "clearTimeout";
+external setTimeout: (unit => unit, int) => timeoutId = "setTimeout";
+external clearTimeout: timeoutId => unit = "clearTimeout";
 
 let id = setTimeout(() => Js.log("hello"), 100);
 let () = clearTimeout(id);
@@ -1482,14 +1479,14 @@ Global bindings can also be applied to values:
 (* Abstract type for `document` *)
 type document
 
-external document : document = "document" [@@bs.val]
+external document : document = "document"
 let document = document
 ```
 ```reasonml
 /* Abstract type for `document` */
 type document;
 
-[@bs.val] external document: document = "document";
+external document: document = "document";
 let document = document;
 ```
 
@@ -1501,15 +1498,15 @@ var doc = document;
 
 ### Using functions from other JavaScript modules
 
-`bs.module` is like the `bs.val` attribute, but it accepts a string with the
-name of the module, or the relative path to it.
+`mel.module` allows to bind to values that belong to another JavaScript module.
+It accepts a string with the name of the module, or the relative path to it.
 
 ```ocaml
-external dirname : string -> string = "dirname" [@@bs.module "path"]
+external dirname : string -> string = "dirname" [@@mel.module "path"]
 let root = dirname "/User/github"
 ```
 ```reasonml
-[@bs.module "path"] external dirname: string => string = "dirname";
+[@mel.module "path"] external dirname: string => string = "dirname";
 let root = dirname("/User/github");
 ```
 
@@ -1523,7 +1520,7 @@ var root = Path.dirname("/User/github");
 ### Binding to properties inside a module or global
 
 For cases when we need to create bindings for a property within a module or a
-global JavaScript object, Melange provides the `bs.scope` attribute.
+global JavaScript object, Melange provides the `mel.scope` attribute.
 
 For example, if we want to write some bindings for a specific property
 `commands` from [the `vscode`
@@ -1533,13 +1530,13 @@ can do:
 ```ocaml
 type param
 external executeCommands : string -> param array -> unit = ""
-  [@@bs.scope "commands"] [@@bs.module "vscode"] [@@bs.variadic]
+  [@@mel.scope "commands"] [@@mel.module "vscode"] [@@mel.variadic]
 
 let f a b c = executeCommands "hi" [| a; b; c |]
 ```
 ```reasonml
 type param;
-[@bs.scope "commands"] [@bs.module "vscode"] [@bs.variadic]
+[@mel.scope "commands"] [@mel.module "vscode"] [@mel.variadic]
 external executeCommands: (string, array(param)) => unit;
 
 let f = (a, b, c) => executeCommands("hi", [|a, b, c|]);
@@ -1555,8 +1552,8 @@ function f(a, b, c) {
 }
 ```
 
-The `bs.scope` attribute can take multiple arguments as payload, in case we want
-to reach deeper into the object from the module we are importing.
+The `mel.scope` attribute can take multiple arguments as payload, in case we
+want to reach deeper into the object from the module we are importing.
 
 For example:
 
@@ -1564,14 +1561,14 @@ For example:
 type t
 
 external back : t = "back"
-  [@@bs.module "expo-camera"] [@@bs.scope "Camera", "Constants", "Type"]
+  [@@mel.module "expo-camera"] [@@mel.scope "Camera", "Constants", "Type"]
 
 let camera_type_back = back
 ```
 ```reasonml
 type t;
 
-[@bs.module "expo-camera"] [@bs.scope ("Camera", "Constants", "Type")]
+[@mel.module "expo-camera"] [@mel.scope ("Camera", "Constants", "Type")]
 external back: t = "back";
 
 let camera_type_back = back;
@@ -1585,16 +1582,16 @@ var ExpoCamera = require("expo-camera");
 var camera_type_back = ExpoCamera.Camera.Constants.Type.back;
 ```
 
-It can also be used in combination with other attributes besides `bs.module`,
-like `bs.val`:
+It can be used without `mel.module`, to created scoped bindings to global
+values:
 
 ```ocaml
-external imul : int -> int -> int = "imul" [@@bs.val] [@@bs.scope "Math"]
+external imul : int -> int -> int = "imul" [@@mel.scope "Math"]
 
 let res = imul 1 2
 ```
 ```reasonml
-[@bs.val] [@bs.scope "Math"] external imul: (int, int) => int = "imul";
+[@mel.scope "Math"] external imul: (int, int) => int = "imul";
 
 let res = imul(1, 2);
 ```
@@ -1605,20 +1602,20 @@ Which produces:
 var res = Math.imul(1, 2);
 ```
 
-Or it can be used together with `bs.new`:
+Or it can be used together with `mel.new`:
 
 ```ocaml
 type t
 
 external create : unit -> t = "GUI"
-  [@@bs.new] [@@bs.scope "default"] [@@bs.module "dat.gui"]
+  [@@mel.new] [@@mel.scope "default"] [@@mel.module "dat.gui"]
 
 let gui = create ()
 ```
 ```reasonml
 type t;
 
-[@bs.new] [@bs.scope "default"] [@bs.module "dat.gui"]
+[@mel.new] [@mel.scope "default"] [@mel.module "dat.gui"]
 external create: unit => t = "GUI";
 
 let gui = create();
@@ -1719,15 +1716,15 @@ MyGame.draw(10, 20, undefined);
 ### Calling an object method
 
 If we need to call a JavaScript method, Melange provides the attribute
-`bs.send`:
+`mel.send`:
 
 ```ocaml
 (* Abstract type for the `document` global *)
 type document
 
-external document : document = "document" [@@bs.val]
+external document : document = "document"
 external get_by_id : document -> string -> Dom.element = "getElementById"
-  [@@bs.send]
+  [@@mel.send]
 
 let el = get_by_id document "my-id"
 ```
@@ -1735,8 +1732,8 @@ let el = get_by_id document "my-id"
 /* Abstract type for the `document` global */
 type document;
 
-[@bs.val] external document: document = "document";
-[@bs.send]
+external document: document = "document";
+[@mel.send]
 external get_by_id: (document, string) => Dom.element = "getElementById";
 
 let el = get_by_id(document, "my-id");
@@ -1748,23 +1745,23 @@ Generates:
 var el = document.getElementById("my-id");
 ```
 
-When using `bs.send`, the first argument will be the object that holds the
+When using `mel.send`, the first argument will be the object that holds the
 property with the function we want to call. This combines well with the pipe
 first operator <code class="text-ocaml">\|.</code><code
 class="text-reasonml">\-\></code>, see the ["Chaining"](#chaining) section
 below.
 
 If we want to design our bindings to be used with OCaml pipe last operator `|>`,
-there is an alternate `bs.send.pipe` attribute. Let’s rewrite the example above
+there is an alternate `mel.send.pipe` attribute. Let’s rewrite the example above
 using it:
 
 ```ocaml
 (* Abstract type for the `document` global *)
 type document
 
-external document : document = "document" [@@bs.val]
+external document : document = "document"
 external get_by_id : string -> Dom.element = "getElementById"
-  [@@bs.send.pipe: document]
+  [@@mel.send.pipe: document]
 
 let el = get_by_id "my-id" document
 ```
@@ -1772,14 +1769,14 @@ let el = get_by_id "my-id" document
 /* Abstract type for the `document` global */
 type document;
 
-[@bs.val] external document: document = "document";
-[@bs.send.pipe: document]
+external document: document = "document";
+[@mel.send.pipe: document]
 external get_by_id: string => Dom.element = "getElementById";
 
 let el = get_by_id("my-id", document);
 ```
 
-Generates the same code as `bs.send`:
+Generates the same code as `mel.send`:
 
 ```js
 var el = document.getElementById("my-id");
@@ -1791,10 +1788,10 @@ It is common to find this kind of API in JavaScript: `foo().bar().baz()`. This
 kind of API can be designed with Melange externals. Depending on which
 convention we want to use, there are two attributes available:
 
-- For a data-first convention, the `bs.send` attribute, in combination with [the
-  pipe first operator](#pipe-first) <code class="text-ocaml">\|.</code><code
-  class="text-reasonml">\-\></code>
-- For a data-last convention, the `bs.send.pipe` attribute, in combination with
+- For a data-first convention, the `mel.send` attribute, in combination with
+  [the pipe first operator](#pipe-first) <code
+  class="text-ocaml">\|.</code><code class="text-reasonml">\-\></code>
+- For a data-last convention, the `mel.send.pipe` attribute, in combination with
   OCaml [pipe last operator](#pipe-last) `|>`.
 
 Let’s see first an example of chaining using data-first convention with the pipe
@@ -1805,12 +1802,12 @@ class="text-reasonml">\-\></code>:
 (* Abstract type for the `document` global *)
 type document
 
-external document : document = "document" [@@bs.val]
+external document : document = "document"
 external get_by_id : document -> string -> Dom.element = "getElementById"
-  [@@bs.send]
+  [@@mel.send]
 external get_by_classname : Dom.element -> string -> Dom.element
   = "getElementsByClassName"
-  [@@bs.send]
+  [@@mel.send]
 
 let el = document |. get_by_id "my-id" |. get_by_classname "my-class"
 ```
@@ -1818,10 +1815,10 @@ let el = document |. get_by_id "my-id" |. get_by_classname "my-class"
 /* Abstract type for the `document` global */
 type document;
 
-[@bs.val] external document: document = "document";
-[@bs.send]
+external document: document = "document";
+[@mel.send]
 external get_by_id: (document, string) => Dom.element = "getElementById";
-[@bs.send]
+[@mel.send]
 external get_by_classname: (Dom.element, string) => Dom.element =
   "getElementsByClassName";
 
@@ -1840,11 +1837,11 @@ Now with pipe last operator `|>`:
 (* Abstract type for the `document` global *)
 type document
 
-external document : document = "document" [@@bs.val]
+external document : document = "document"
 external get_by_id : string -> Dom.element = "getElementById"
-  [@@bs.send.pipe: document]
+  [@@mel.send.pipe: document]
 external get_by_classname : string -> Dom.element = "getElementsByClassName"
-  [@@bs.send.pipe: Dom.element]
+  [@@mel.send.pipe: Dom.element]
 
 let el = document |> get_by_id "my-id" |> get_by_classname "my-class"
 ```
@@ -1852,10 +1849,10 @@ let el = document |> get_by_id "my-id" |> get_by_classname "my-class"
 /* Abstract type for the `document` global */
 type document;
 
-[@bs.val] external document: document = "document";
-[@bs.send.pipe: document]
+external document: document = "document";
+[@mel.send.pipe: document]
 external get_by_id: string => Dom.element = "getElementById";
-[@bs.send.pipe: Dom.element]
+[@mel.send.pipe: Dom.element]
 external get_by_classname: string => Dom.element = "getElementsByClassName";
 
 let el = document |> get_by_id("my-id") |> get_by_classname("my-class");
@@ -1870,17 +1867,17 @@ var el = document.getElementById("my-id").getElementsByClassName("my-class");
 ### Variadic function arguments
 
 Sometimes JavaScript functions take an arbitrary amount of arguments. For these
-cases, Melange provides the `bs.variadic` attribute, which can be attached to
+cases, Melange provides the `mel.variadic` attribute, which can be attached to
 the `external` declaration. However, there is one caveat: all the variadic
 arguments need to belong to the same type.
 
 ```ocaml
 external join : string array -> string = "join"
-  [@@bs.module "path"] [@@bs.variadic]
+  [@@mel.module "path"] [@@mel.variadic]
 let v = join [| "a"; "b" |]
 ```
 ```reasonml
-[@bs.module "path"] [@bs.variadic]
+[@mel.module "path"] [@mel.variadic]
 external join: array(string) => string = "join";
 let v = join([|"a", "b"|]);
 ```
@@ -1901,7 +1898,7 @@ mentioned [in the OCaml attributes section](#reusing-ocaml-attributes):
 ```ocaml
 type hide = Hide : 'a -> hide [@@unboxed]
 
-external join : hide array -> string = "join" [@@bs.module "path"] [@@bs.variadic]
+external join : hide array -> string = "join" [@@mel.module "path"] [@@mel.variadic]
 
 let v = join [| Hide "a"; Hide 2 |]
 ```
@@ -1910,7 +1907,7 @@ let v = join [| Hide "a"; Hide 2 |]
 type hide =
   | Hide('a): hide;
 
-[@bs.module "path"] [@bs.variadic]
+[@mel.module "path"] [@mel.variadic]
 external join: array(hide) => string = "join";
 
 let v = join([|Hide("a"), Hide(2)|]);
@@ -1936,25 +1933,25 @@ If it is possible to enumerate the many forms an overloaded JavaScript function
 can take, a flexible approach is to bind to each form individually:
 
 ```ocaml
-external drawCat : unit -> unit = "draw" [@@bs.module "MyGame"]
-external drawDog : giveName:string -> unit = "draw" [@@bs.module "MyGame"]
+external drawCat : unit -> unit = "draw" [@@mel.module "MyGame"]
+external drawDog : giveName:string -> unit = "draw" [@@mel.module "MyGame"]
 external draw : string -> useRandomAnimal:bool -> unit = "draw"
-  [@@bs.module "MyGame"]
+  [@@mel.module "MyGame"]
 ```
 ```reasonml
-[@bs.module "MyGame"] external drawCat: unit => unit = "draw";
-[@bs.module "MyGame"] external drawDog: (~giveName: string) => unit = "draw";
-[@bs.module "MyGame"]
+[@mel.module "MyGame"] external drawCat: unit => unit = "draw";
+[@mel.module "MyGame"] external drawDog: (~giveName: string) => unit = "draw";
+[@mel.module "MyGame"]
 external draw: (string, ~useRandomAnimal: bool) => unit = "draw";
 ```
 
 Note how all three externals bind to the same JavaScript function, `draw`.
 
-#### Approach 2: Polymorphic variant + `bs.unwrap`
+#### Approach 2: Polymorphic variant + `mel.unwrap`
 
 In some cases, the function has a constant number of arguments but the type of
 the argument can vary. For cases like this, we can model the argument as a
-variant and use the `bs.unwrap` attribute in the external.
+variant and use the `mel.unwrap` attribute in the external.
 
 Let’s say we want to bind to the following JavaScript function:
 
@@ -1971,7 +1968,7 @@ function padLeft(value, padding) {
 ```
 
 As the `padding` argument can be either a number or a string, we can use
-`bs.unwrap` to define it. It is important to note that `bs.unwrap` imposes
+`mel.unwrap` to define it. It is important to note that `mel.unwrap` imposes
 certain requirements on the type it is applied to:
 
 - It needs to be a [polymorphic
@@ -1985,17 +1982,16 @@ external padLeft:
   string
   -> ([ `Str of string
       | `Int of int
-      ] [@bs.unwrap])
+      ] [@mel.unwrap])
   -> string
-  = "padLeft" [@@bs.val]
+  = "padLeft"
 
 let _ = padLeft "Hello World" (`Int 4)
 let _ = padLeft "Hello World" (`Str "Message from Melange: ")
 ```
 ```reasonml
-[@bs.val]
 external padLeft:
-  (string, [@bs.unwrap] [ | `Str(string) | `Int(int)]) => string =
+  (string, [@mel.unwrap] [ | `Str(string) | `Int(int)]) => string =
   "padLeft";
 
 let _ = padLeft("Hello World", `Int(4));
@@ -2011,7 +2007,7 @@ padLeft("Hello World", "Message from Melange: ");
 
 As we saw in the [Non-shared data types](#non-shared-data-types) section, we
 should rather avoid passing variants directly to the JavaScript side. By using
-`bs.unwrap` we get the best of both worlds: from Melange we can use variants,
+`mel.unwrap` we get the best of both worlds: from Melange we can use variants,
 while JavaScript gets the raw values inside them.
 
 ### Using polymorphic variants to bind to enums
@@ -2028,19 +2024,19 @@ not prevent consumers of the external function from calling it using values that
 are unsupported by the JavaScript function. Let’s see how we can use polymorphic
 variants to avoid runtime errors.
 
-If the values are strings, we can use the `bs.string` attribute:
+If the values are strings, we can use the `mel.string` attribute:
 
 ```ocaml
 external read_file_sync :
-  name:string -> ([ `utf8 | `ascii ][@bs.string]) -> string = "readFileSync"
-  [@@bs.module "fs"]
+  name:string -> ([ `utf8 | `ascii ][@mel.string]) -> string = "readFileSync"
+  [@@mel.module "fs"]
 
 let _ = read_file_sync ~name:"xx.txt" `ascii
 ```
 ```reasonml
-[@bs.module "fs"]
+[@mel.module "fs"]
 external read_file_sync:
-  (~name: string, [@bs.string] [ | `utf8 | `ascii]) => string =
+  (~name: string, [@mel.string] [ | `utf8 | `ascii]) => string =
   "readFileSync";
 
 let _ = read_file_sync(~name="xx.txt", `ascii);
@@ -2053,17 +2049,17 @@ var Fs = require("fs");
 Fs.readFileSync("xx.txt", "ascii");
 ```
 
-This technique can be combined with the `bs.as` attribute to modify the strings
+This technique can be combined with the `mel.as` attribute to modify the strings
 produced from the polymorphic variant values. For example:
 
 ```ocaml
 type document
 type style
 
-external document : document = "document" [@@bs.val]
+external document : document = "document"
 external get_by_id : document -> string -> Dom.element = "getElementById"
 [@@mel.send]
-external style : Dom.element -> style = "style" [@@bs.get]
+external style : Dom.element -> style = "style" [@@mel.get]
 external transition_timing_function :
   style ->
   ([ `ease
@@ -2082,10 +2078,10 @@ let () = transition_timing_function element_style `easeIn
 type document;
 type style;
 
-[@bs.val] external document: document = "document";
+external document: document = "document";
 [@mel.send]
 external get_by_id: (document, string) => Dom.element = "getElementById";
-[@bs.get] external style: Dom.element => style = "style";
+[@mel.get] external style: Dom.element => style = "style";
 [@mel.set]
 external transition_timing_function:
   (
@@ -2113,30 +2109,28 @@ var element_style = document.getElementById("my-id").style;
 element_style.transitionTimingFunction = "ease-in";
 ```
 
-Aside from producing string values, Melange also offers `bs.int` to produce
-integer values. `bs.int` can also be combined with `bs.as`:
+Aside from producing string values, Melange also offers `mel.int` to produce
+integer values. `mel.int` can also be combined with `mel.as`:
 
 ```ocaml
 external test_int_type :
-  ([ `on_closed | `on_open [@bs.as 20] | `in_bin ][@bs.int]) -> int
+  ([ `on_closed | `on_open [@mel.as 20] | `in_bin ][@mel.int]) -> int
   = "testIntType"
-  [@@bs.val]
 
 let value = test_int_type `on_open
 ```
 ```reasonml
-[@bs.val]
 external test_int_type:
-  ([@bs.int] [ | `on_closed | [@bs.as 20] `on_open | `in_bin]) => int =
+  ([@mel.int] [ | `on_closed | [@mel.as 20] `on_open | `in_bin]) => int =
   "testIntType";
 
 let value = test_int_type(`on_open);
 ```
 
 In this example, `on_closed` will be encoded as 0, `on_open` will be 20 due to
-the attribute `bs.as` and `in_bin` will be 21, because if no `bs.as` annotation
-is provided for a variant tag, the compiler continues assigning values counting
-up from the previous one.
+the attribute `mel.as` and `in_bin` will be 21, because if no `mel.as`
+annotation is provided for a variant tag, the compiler continues assigning
+values counting up from the previous one.
 
 This code generates:
 
@@ -2154,9 +2148,9 @@ type readline
 
 external on :
   readline ->
-  ([ `close of unit -> unit | `line of string -> unit ][@bs.string]) ->
+  ([ `close of unit -> unit | `line of string -> unit ][@mel.string]) ->
   readline = "on"
-  [@@bs.send]
+  [@@mel.send]
 
 let register rl =
   rl |. on (`close (fun event -> ())) |. on (`line (fun line -> Js.log line))
@@ -2164,11 +2158,11 @@ let register rl =
 ```reasonml
 type readline;
 
-[@bs.send]
+[@mel.send]
 external on:
   (
     readline,
-    [@bs.string] [ | `close(unit => unit) | `line(string => unit)]
+    [@mel.string] [ | `close(unit => unit) | `line(string => unit)]
   ) =>
   readline =
   "on";
@@ -2192,21 +2186,19 @@ function register(rl) {
 ### Constant values as arguments
 
 Sometimes we want to call a JavaScript function and make sure one of the
-arguments is always constant. For this, the `[@bs.as]` attribute can be combined
-with the wildcard pattern `_`:
+arguments is always constant. For this, the `[@mel.as]` attribute can be
+combined with the wildcard pattern `_`:
 
 ```ocaml
-external process_on_exit : (_[@bs.as "exit"]) -> (int -> unit) -> unit
+external process_on_exit : (_[@mel.as "exit"]) -> (int -> unit) -> unit
   = "process.on"
-  [@@bs.val]
 
 let () =
   process_on_exit (fun exit_code ->
     Js.log ("error code: " ^ string_of_int exit_code))
 ```
 ```reasonml
-[@bs.val]
-external process_on_exit: ([@bs.as "exit"] _, int => unit) => unit =
+external process_on_exit: ([@mel.as "exit"] _, int => unit) => unit =
   "process.on";
 
 let () =
@@ -2223,11 +2215,11 @@ process.on("exit", function (exitCode) {
 });
 ```
 
-The `bs.as "exit"` and the wildcard `_` pattern together will tell Melange to
+The `mel.as "exit"` and the wildcard `_` pattern together will tell Melange to
 compile the first argument of the JavaScript function to the string `"exit"`.
 
-You can also use any JSON literal by passing a quoted string to `bs.as`: `bs.as
-{json|true|json}` or `bs.as {json|{"name": "John"}|json}`.
+You can also use any JSON literal by passing a quoted string to `mel.as`:
+`mel.as {json|true|json}` or `mel.as {json|{"name": "John"}|json}`.
 
 ### Binding to callbacks
 
@@ -2281,10 +2273,8 @@ A naive external function declaration could be as below:
 
 ```ocaml
 external map : 'a array -> 'b array -> ('a -> 'b -> 'c) -> 'c array = "map"
-  [@@bs.val]
 ```
 ```reasonml
-[@bs.val]
 external map: (array('a), array('b), ('a, 'b) => 'c) => array('c) = "map";
 ```
 
@@ -2338,10 +2328,8 @@ In the example above:
 ```ocaml
 external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@bs]) -> 'c array
   = "map"
-  [@@bs.val]
 ```
 ```reasonml
-[@bs.val]
 external map: (array('a), array('b), (. 'a, 'b) => 'c) => array('c) = "map";
 ```
 
@@ -2385,20 +2373,18 @@ Annotating function definitions can be quite cumbersome when writing a lot of
 externals.
 
 To work around the verbosity, Melange offers another attribute called
-`bs.uncurry`.
+`mel.uncurry`.
 
 Let’s see how we could use it in the previous example. We just need to replace
-`bs` with `bs.uncurry`:
+`bs` with `mel.uncurry`:
 
 ```ocaml
 external map :
-  'a array -> 'b array -> (('a -> 'b -> 'c)[@bs.uncurry]) -> 'c array = "map"
-  [@@bs.val]
+  'a array -> 'b array -> (('a -> 'b -> 'c)[@mel.uncurry]) -> 'c array = "map"
 ```
 ```reasonml
-[@bs.val]
 external map:
-  (array('a), array('b), [@bs.uncurry] (('a, 'b) => 'c)) => array('c) =
+  (array('a), array('b), [@mel.uncurry] (('a, 'b) => 'c)) => array('c) =
   "map";
 ```
 
@@ -2415,8 +2401,8 @@ let _ = map([||], [||], add);
 
 Everything works fine now, without having to attach any attributes to `add`.
 
-The main difference between `bs` and `bs.uncurry` is that the latter only works
-with externals. `bs.uncurry` is the recommended option to use for bindings,
+The main difference between `bs` and `mel.uncurry` is that the latter only works
+with externals. `mel.uncurry` is the recommended option to use for bindings,
 while `bs` remains useful for those use cases where performance is crucial and
 we want the JavaScript functions generated from OCaml ones to not be applied
 partially.
@@ -2435,27 +2421,27 @@ x.onload = function(v) {
 
 Inside the `x.onload` callback, `this` would be pointing to `x`. It would not be
 correct to declare `x.onload` of type `unit -> unit`. Instead, Melange
-introduces a special attribute, `bs.this`, which allows to type `x` as this:
+introduces a special attribute, `mel.this`, which allows to type `x` as this:
 
 ```ocaml
 type x
-external x : x = "x" [@@bs.val]
-external set_onload : x -> ((x -> int -> unit)[@bs.this]) -> unit = "onload"
-  [@@bs.set]
-external resp : x -> int = "response" [@@bs.get]
+external x : x = "x"
+external set_onload : x -> ((x -> int -> unit)[@mel.this]) -> unit = "onload"
+  [@@mel.set]
+external resp : x -> int = "response" [@@mel.get]
 let _ =
   set_onload x
     begin
-      fun [@bs.this] o v -> Js.log (resp o + v)
+      fun [@mel.this] o v -> Js.log (resp o + v)
     end
 ```
 ```reasonml
 type x;
-[@bs.val] external x: x = "x";
-[@bs.set]
-external set_onload: (x, [@bs.this] ((x, int) => unit)) => unit = "onload";
-[@bs.get] external resp: x => int = "response";
-let _ = set_onload(x, [@bs.this] (o, v) => Js.log(resp(o) + v));
+external x: x = "x";
+[@mel.set]
+external set_onload: (x, [@mel.this] ((x, int) => unit)) => unit = "onload";
+[@mel.get] external resp: x => int = "response";
+let _ = set_onload(x, [@mel.this] (o, v) => Js.log(resp(o) + v));
 ```
 
 Which generates:
@@ -2475,17 +2461,17 @@ JavaScript models `null` and `undefined` differently, whereas it can be useful
 to treat both as <span class="text-ocaml">`'a option`</span><span
 class="text-reasonml">`option('a)`</span> in Melange.
 
-Melange understands the `bs.return` attribute in externals to model how nullable
-return types should be wrapped at the bindings boundary. An `external` value
-with `bs.return` converts the return value to an `option` type, avoiding the
-need for extra wrapping / unwrapping with functions such as
+Melange understands the `mel.return` attribute in externals to model how
+nullable return types should be wrapped at the bindings boundary. An `external`
+value with `mel.return` converts the return value to an `option` type, avoiding
+the need for extra wrapping / unwrapping with functions such as
 `Js.Nullable.toOption`.
 
 ```ocaml
 type element
 type document
 external get_by_id : document -> string -> element option = "getElementById"
-  [@@bs.send] [@@bs.return nullable]
+  [@@mel.send] [@@mel.return nullable]
 
 let test document =
   let elem = get_by_id document "header" in
@@ -2496,7 +2482,7 @@ let test document =
 ```reasonml
 type element;
 type document;
-[@bs.send] [@bs.return nullable]
+[@mel.send] [@mel.return nullable]
 external get_by_id: (document, string) => option(element) = "getElementById";
 
 let test = document => {
@@ -2521,9 +2507,9 @@ function test($$document) {
 }
 ```
 
-The `bs.return` attribute takes an attribute payload, as seen with <span
-class="text-ocaml">`[@@bs.return nullable]`</span><span
-class="text-reasonml">`[@bs.return nullable]`</span> above. Currently 4
+The `mel.return` attribute takes an attribute payload, as seen with <span
+class="text-ocaml">`[@@mel.return nullable]`</span><span
+class="text-reasonml">`[@mel.return nullable]`</span> above. Currently 4
 directives are supported: `null_to_opt`, `undefined_to_opt`, `nullable` and
 `identity`.
 
@@ -2544,8 +2530,8 @@ these types, Melange includes an attribute `deriving` that helps generating
 conversion functions, as well as functions to create values from these types. In
 particular, for variants and polymorphic variants.
 
-Additionally, `deriving` can be used with record types, to generate setters
-and getters as well as creation functions.
+Additionally, `deriving` can be used with record types, to generate setters and
+getters as well as creation functions.
 
 ### Variants
 
@@ -2628,13 +2614,13 @@ const click = generators.click;
 
 #### Conversion functions
 
-Use `@deriving jsConverter` on a variant type to create converter functions
-that allow to transform back and forth between JavaScript integers and Melange
+Use `@deriving jsConverter` on a variant type to create converter functions that
+allow to transform back and forth between JavaScript integers and Melange
 variant values.
 
 There are a few differences with `@deriving accessors`:
 
-- `jsConverter` works with the `bs.as` attribute, while `accessors` does not
+- `jsConverter` works with the `mel.as` attribute, while `accessors` does not
 - `jsConverter` does not support variant tags with payload, while `accessors`
   does
 - `jsConverter` generates functions to transform values back and forth, while
@@ -2646,7 +2632,7 @@ given the constraints above:
 ```ocaml
 type action =
   | Click
-  | Submit [@bs.as 3]
+  | Submit [@mel.as 3]
   | Cancel
 [@@deriving jsConverter]
 ```
@@ -2654,7 +2640,7 @@ type action =
 [@deriving jsConverter]
 type action =
   | Click
-  | [@bs.as 3] Submit
+  | [@mel.as 3] Submit
   | Cancel;
 ```
 
@@ -2672,8 +2658,8 @@ external actionFromJs: int => option(action) = ;
 ```
 
 `actionToJs` returns integers from values of `action` type. It will start with 0
-for `Click`, 3 for `Submit` (because it was annotated with `bs.as`), and then 4
-for `Cancel`, in the same way that we described when [using `bs.int` with
+for `Click`, 3 for `Submit` (because it was annotated with `mel.as`), and then 4
+for `Cancel`, in the same way that we described when [using `mel.int` with
 polymorphic variants](#using-polymorphic-variants-to-bind-to-enums).
 
 `actionFromJs` returns a value of type `option`, because not every integer can
@@ -2688,7 +2674,7 @@ payload with `@deriving`:
 ```ocaml
 type action =
   | Click
-  | Submit [@bs.as 3]
+  | Submit [@mel.as 3]
   | Cancel
 [@@deriving jsConverter {  newType }]
 ```
@@ -2696,7 +2682,7 @@ type action =
 [@deriving jsConverter({newType: newType})]
 type action =
   | Click
-  | [@bs.as 3] Submit
+  | [@mel.as 3] Submit
   | Cancel;
 ```
 
@@ -2720,8 +2706,8 @@ way to create an `abs_action` is by calling the `actionToJs` function.
 
 ### Polymorphic variants
 
-The `@deriving jsConverter` attribute is applicable to polymorphic variants
-as well.
+The `@deriving jsConverter` attribute is applicable to polymorphic variants as
+well.
 
 > **_NOTE:_** Similarly to variants, the `@deriving jsConverter` attribute
 > cannot be used when the polymorphic variant tags have payloads. Refer to the
@@ -2733,14 +2719,14 @@ Let’s see an example:
 ```ocaml
 type action =
   [ `Click
-  | `Submit [@bs.as "submit"]
+  | `Submit [@mel.as "submit"]
   | `Cancel
   ]
 [@@deriving jsConverter]
 ```
 ```reasonml
 [@deriving jsConverter]
-type action = [ | `Click | [@bs.as "submit"] `Submit | `Cancel];
+type action = [ | `Click | [@mel.as "submit"] `Submit | `Cancel];
 ```
 
 Akin to the variant example, the following two functions will be generated:
@@ -2763,8 +2749,8 @@ variants.
 
 #### Accessing fields
 
-Use `@deriving accessors` on a record type to create accessor functions for
-its record field names.
+Use `@deriving accessors` on a record type to create accessor functions for its
+record field names.
 
 ```ocaml
 type pet = { name : string } [@@deriving accessors]
@@ -2842,9 +2828,9 @@ An example of this use-case would be expecting `{ name = "John"; age = None }`
 to generate a JavaScript such as `{name: "Carl"}`, where the `age` key doesn’t
 appear.
 
-The `@deriving abstract` attribute exists to solve this problem. When present
-in a record type, `@deriving abstract` makes the record definition abstract
-and generates the following functions instead:
+The `@deriving abstract` attribute exists to solve this problem. When present in
+a record type, `@deriving abstract` makes the record definition abstract and
+generates the following functions instead:
 
 - A constructor function for creating values of the type
 - Getters and setters for accessing the record fields
@@ -3010,18 +2996,18 @@ Another distinction from the previous example is that the `person` constructor
 function no longer requires the final `unit` argument since we have excluded the
 optional field in this case.
 
-> **_NOTE:_** The `bs.as` attribute can still be applied to record fields when
+> **_NOTE:_** The `mel.as` attribute can still be applied to record fields when
 > the record type is annotated with `deriving`, allowing for the renaming of
 > fields in the resulting JavaScript objects, as demonstrated in the section
 > about [binding to objects with static
 > shape](#objects-with-static-shape-record-like). However, the option to pass
-> indices to the `bs.as` decorator (like `[@bs.as "0"]`) to change the runtime
+> indices to the `mel.as` decorator (like `[@mel.as "0"]`) to change the runtime
 > representation to an array is not available when using `deriving`.
 
 ##### Compatibility with OCaml features
 
-The `@deriving abstract` attribute and its lightweight variant can be used
-with [mutable
+The `@deriving abstract` attribute and its lightweight variant can be used with
+[mutable
 fields](https://v2.ocaml.org/manual/coreexamples.html#s:imperative-features) and
 [private types](https://v2.ocaml.org/manual/privatetypes.html), which are
 features inherited by Melange from OCaml.

--- a/documentation-site.opam
+++ b/documentation-site.opam
@@ -13,8 +13,8 @@ license: "MIT"
 homepage: "https://github.com/melange-re/melange-re.github.io"
 bug-reports: "https://github.com/melange-re/melange-re.github.io"
 depends: [
-  "ocaml" {>= "4.14.0" & < "5.0.0"}
-  "dune" {>= "3.8.0" & < "4.0.0"}
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.8.0"}
   "reason-react" {dev}
   "reason-react-ppx" {dev}
   "ocamlformat"
@@ -27,12 +27,12 @@ depends: [
 ]
 dev-repo: "git+https://github.com/melange-re/melange-re.github.io.git"
 pin-depends: [
-  [ "melange.dev" "git+https://github.com/melange-re/melange.git#c6dfaff84c605b06ce27ce39a4b8c1a492b86d22" ]
-  [ "reason-react.dev" "git+https://github.com/reasonml/reason-react.git#9e70d7548918816f1c0d8be8bdc66b6deabd339a" ]
-  [ "reason-react-ppx.dev" "git+https://github.com/reasonml/reason-react.git#9e70d7548918816f1c0d8be8bdc66b6deabd339a" ]
-  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#c6dfaff84c605b06ce27ce39a4b8c1a492b86d22" ]
+  [ "melange.dev" "git+https://github.com/melange-re/melange.git#ccdfb740a4df95530b681caba1385b870447d061" ]
+  [ "reason-react.dev" "git+https://github.com/reasonml/reason-react.git#53947f3300513623a64594d73ae6be2207116513" ]
+  [ "reason-react-ppx.dev" "git+https://github.com/reasonml/reason-react.git#53947f3300513623a64594d73ae6be2207116513" ]
+  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#ccdfb740a4df95530b681caba1385b870447d061" ]
   [ "cmarkit.dev" "git+https://github.com/dbuenzli/cmarkit.git#f37c8ea86fd0be8dba7a8babcee3682e0e047d91" ]
-  [ "reason.dev" "git+https://github.com/reasonml/reason.git#95485d5c4527641903d9bec81e80aa3c5dfb3d30"]
+  [ "reason.dev" "git+https://github.com/reasonml/reason.git#972261dab3b651ff8ab9b8b9fcc32940595073dc"]
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/scripts/build-system.t
+++ b/scripts/build-system.t
@@ -21,6 +21,11 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 1, characters 12-18:
+  1 | let dir = [%bs.raw "__dirname"]
+                  ^^^^^^
+  Error: Uninterpreted extension 'bs.raw'.
+  [1]
 
   $ cat > input.ml <<\EOF
   > let () = Js.log Lib.name

--- a/scripts/build-system.t
+++ b/scripts/build-system.t
@@ -15,17 +15,12 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ cat > input.ml <<\EOF
-  > let dir = [%bs.raw "__dirname"]
+  > let dir = [%mel.raw "__dirname"]
   > let file = "name.txt"
   > let name = Node.Fs.readFileSync (dir ^ "/" ^ file) `ascii
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 12-18:
-  1 | let dir = [%bs.raw "__dirname"]
-                  ^^^^^^
-  Error: Uninterpreted extension 'bs.raw'.
-  [1]
 
   $ cat > input.ml <<\EOF
   > let () = Js.log Lib.name

--- a/scripts/build-system.t
+++ b/scripts/build-system.t
@@ -10,7 +10,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > (melange.emit
   >  (emit_stdlib false)
   >  (target output)
-  >  (libraries melange.node)
+  >  (libraries melange.dom melange.node)
   >  (preprocess (pps melange.ppx)))
   > EOF
 

--- a/scripts/communicate-with-javascript.t
+++ b/scripts/communicate-with-javascript.t
@@ -55,18 +55,13 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   name : string;
   >   age : int;
   > }
-  > [@@deriving { abstract = light }]
+  > [@@deriving abstract { light }]
   > 
   > let alice = person ~name:"Alice" ~age:20
   > let aliceName = name alice
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 12-32:
-  5 | [@@deriving { abstract = light }]
-                  ^^^^^^^^^^^^^^^^^^^^
-  Error: tuple expected
-  [1]
 
   $ cat > input.ml <<\EOF
   > 
@@ -632,8 +627,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > type t
   > external create : int -> t = "Int32Array" [@@mel.new]
-  > external get : t -> int -> int = "get" [@@mel.get_index]
-  > external set : t -> int -> int -> unit = "set" [@@mel.set_index]
+  > external get : t -> int -> int = "" [@@mel.get_index]
+  > external set : t -> int -> int -> unit = "" [@@mel.set_index]
   > 
   > let () =
   >   let i32arr = (create 3) in
@@ -642,11 +637,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 3, characters 42-55:
-  3 | external get : t -> int -> int = "get" [@@mel.get_index]
-                                                ^^^^^^^^^^^^^
-  Error: @get_index this particular external's name needs to be a placeholder empty string
-  [1]
 
   $ cat > input.ml <<\EOF
   > (* Abstract type for the `document` value *)

--- a/scripts/communicate-with-javascript.t
+++ b/scripts/communicate-with-javascript.t
@@ -299,15 +299,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > let add = fun [@bs] x y -> x + y
+  > let add = fun [@u] x y -> x + y
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 16-18:
-  1 | let add = fun [@bs] x y -> x + y
-                      ^^
-  Alert deprecated: The `[@bs]' uncurry attribute is deprecated and will be removed in the next release.
-  Use `[@u]' instead.
 
   $ cat > input.ml <<\EOF
   > let add x y = x + y
@@ -323,16 +318,11 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   [1]
 
   $ cat > input.ml <<\EOF
-  > external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@bs]) -> 'c array
+  > external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@u]) -> 'c array
   >   = "map"
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 58-60:
-  1 | external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@bs]) -> 'c array
-                                                                ^^
-  Alert deprecated: The `[@bs]' uncurry attribute is deprecated and will be removed in the next release.
-  Use `[@u]' instead.
 
   $ cat > input.ml <<\EOF
   > let add x = let partial y = x + y in partial

--- a/scripts/communicate-with-javascript.t
+++ b/scripts/communicate-with-javascript.t
@@ -169,7 +169,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > type action =
   >   [ `Click
-  >   | `Submit [@bs.as "submit"]
+  >   | `Submit [@mel.as "submit"]
   >   | `Cancel
   >   ]
   > [@@deriving jsConverter]
@@ -194,7 +194,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > type action =
   >   | Click
-  >   | Submit [@bs.as 3]
+  >   | Submit [@mel.as 3]
   >   | Cancel
   > [@@deriving jsConverter {  newType }]
   > EOF
@@ -218,7 +218,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > type action =
   >   | Click
-  >   | Submit [@bs.as 3]
+  >   | Submit [@mel.as 3]
   >   | Cancel
   > [@@deriving jsConverter]
   > EOF
@@ -252,7 +252,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > type element
   > type document
   > external get_by_id : document -> string -> element option = "getElementById"
-  >   [@@bs.send] [@@bs.return nullable]
+  >   [@@mel.send] [@@mel.return nullable]
   > 
   > let test document =
   >   let elem = get_by_id document "header" in
@@ -265,14 +265,14 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > type x
-  > external x : x = "x" [@@bs.val]
-  > external set_onload : x -> ((x -> int -> unit)[@bs.this]) -> unit = "onload"
-  >   [@@bs.set]
-  > external resp : x -> int = "response" [@@bs.get]
+  > external x : x = "x"
+  > external set_onload : x -> ((x -> int -> unit)[@mel.this]) -> unit = "onload"
+  >   [@@mel.set]
+  > external resp : x -> int = "response" [@@mel.get]
   > let _ =
   >   set_onload x
   >     begin
-  >       fun [@bs.this] o v -> Js.log (resp o + v)
+  >       fun [@mel.this] o v -> Js.log (resp o + v)
   >     end
   > EOF
 
@@ -293,8 +293,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > external map :
-  >   'a array -> 'b array -> (('a -> 'b -> 'c)[@bs.uncurry]) -> 'c array = "map"
-  >   [@@bs.val]
+  >   'a array -> 'b array -> (('a -> 'b -> 'c)[@mel.uncurry]) -> 'c array = "map"
   > EOF
 
   $ dune build @melange
@@ -304,6 +303,11 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 1, characters 16-18:
+  1 | let add = fun [@bs] x y -> x + y
+                      ^^
+  Alert deprecated: The `[@bs]' uncurry attribute is deprecated and will be removed in the next release.
+  Use `[@u]' instead.
 
   $ cat > input.ml <<\EOF
   > let add x y = x + y
@@ -321,10 +325,14 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@bs]) -> 'c array
   >   = "map"
-  >   [@@bs.val]
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 1, characters 58-60:
+  1 | external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@bs]) -> 'c array
+                                                                ^^
+  Alert deprecated: The `[@bs]' uncurry attribute is deprecated and will be removed in the next release.
+  Use `[@u]' instead.
 
   $ cat > input.ml <<\EOF
   > let add x = let partial y = x + y in partial
@@ -334,7 +342,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > external map : 'a array -> 'b array -> ('a -> 'b -> 'c) -> 'c array = "map"
-  >   [@@bs.val]
   > EOF
 
   $ dune build @melange
@@ -346,9 +353,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > external process_on_exit : (_[@bs.as "exit"]) -> (int -> unit) -> unit
+  > external process_on_exit : (_[@mel.as "exit"]) -> (int -> unit) -> unit
   >   = "process.on"
-  >   [@@bs.val]
   > 
   > let () =
   >   process_on_exit (fun exit_code ->
@@ -362,9 +368,9 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > 
   > external on :
   >   readline ->
-  >   ([ `close of unit -> unit | `line of string -> unit ][@bs.string]) ->
+  >   ([ `close of unit -> unit | `line of string -> unit ][@mel.string]) ->
   >   readline = "on"
-  >   [@@bs.send]
+  >   [@@mel.send]
   > 
   > let register rl =
   >   rl |. on (`close (fun event -> ())) |. on (`line (fun line -> Js.log line))
@@ -379,9 +385,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > external test_int_type :
-  >   ([ `on_closed | `on_open [@bs.as 20] | `in_bin ][@bs.int]) -> int
+  >   ([ `on_closed | `on_open [@mel.as 20] | `in_bin ][@mel.int]) -> int
   >   = "testIntType"
-  >   [@@bs.val]
   > 
   > let value = test_int_type `on_open
   > EOF
@@ -392,10 +397,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > type document
   > type style
   > 
-  > external document : document = "document" [@@bs.val]
+  > external document : document = "document"
   > external get_by_id : document -> string -> Dom.element = "getElementById"
   > [@@mel.send]
-  > external style : Dom.element -> style = "style" [@@bs.get]
+  > external style : Dom.element -> style = "style" [@@mel.get]
   > external transition_timing_function :
   >   style ->
   >   ([ `ease
@@ -412,29 +417,34 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 5, characters 43-54:
+  5 | external get_by_id : document -> string -> Dom.element = "getElementById"
+                                                 ^^^^^^^^^^^
+  Error: Unbound module Dom
+  [1]
 
   $ cat > input.ml <<\EOF
   > external read_file_sync :
-  >   name:string -> ([ `utf8 | `ascii ][@bs.string]) -> string = "readFileSync"
-  >   [@@bs.module "fs"]
+  >   name:string -> ([ `utf8 | `ascii ][@mel.string]) -> string = "readFileSync"
+  >   [@@mel.module "fs"]
   > 
   > let _ = read_file_sync ~name:"xx.txt" `ascii
   > EOF
 
   $ dune build @melange
   File "input.ml", line 2, characters 18-36:
-  2 |   name:string -> ([ `utf8 | `ascii ][@bs.string]) -> string = "readFileSync"
+  2 |   name:string -> ([ `utf8 | `ascii ][@mel.string]) -> string = "readFileSync"
                         ^^^^^^^^^^^^^^^^^^
-  Alert redundant: [@bs.string] is redundant here, you can safely remove it
+  Alert redundant: [@mel.string] is redundant here, you can safely remove it
 
   $ cat > input.ml <<\EOF
   > external padLeft:
   >   string
   >   -> ([ `Str of string
   >       | `Int of int
-  >       ] [@bs.unwrap])
+  >       ] [@mel.unwrap])
   >   -> string
-  >   = "padLeft" [@@bs.val]
+  >   = "padLeft"
   > 
   > let _ = padLeft "Hello World" (`Int 4)
   > let _ = padLeft "Hello World" (`Str "Message from Melange: ")
@@ -443,10 +453,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > external drawCat : unit -> unit = "draw" [@@bs.module "MyGame"]
-  > external drawDog : giveName:string -> unit = "draw" [@@bs.module "MyGame"]
+  > external drawCat : unit -> unit = "draw" [@@mel.module "MyGame"]
+  > external drawDog : giveName:string -> unit = "draw" [@@mel.module "MyGame"]
   > external draw : string -> useRandomAnimal:bool -> unit = "draw"
-  >   [@@bs.module "MyGame"]
+  >   [@@mel.module "MyGame"]
   > EOF
 
   $ dune build @melange
@@ -454,7 +464,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > type hide = Hide : 'a -> hide [@@unboxed]
   > 
-  > external join : hide array -> string = "join" [@@bs.module "path"] [@@bs.variadic]
+  > external join : hide array -> string = "join" [@@mel.module "path"] [@@mel.variadic]
   > 
   > let v = join [| Hide "a"; Hide 2 |]
   > EOF
@@ -463,7 +473,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > external join : string array -> string = "join"
-  >   [@@bs.module "path"] [@@bs.variadic]
+  >   [@@mel.module "path"] [@@mel.variadic]
   > let v = join [| "a"; "b" |]
   > EOF
 
@@ -473,58 +483,78 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > (* Abstract type for the `document` global *)
   > type document
   > 
-  > external document : document = "document" [@@bs.val]
+  > external document : document = "document"
   > external get_by_id : string -> Dom.element = "getElementById"
-  >   [@@bs.send.pipe: document]
+  >   [@@mel.send.pipe: document]
   > external get_by_classname : string -> Dom.element = "getElementsByClassName"
-  >   [@@bs.send.pipe: Dom.element]
+  >   [@@mel.send.pipe: Dom.element]
   > 
   > let el = document |> get_by_id "my-id" |> get_by_classname "my-class"
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 5, characters 31-42:
+  5 | external get_by_id : string -> Dom.element = "getElementById"
+                                     ^^^^^^^^^^^
+  Error: Unbound module Dom
+  [1]
 
   $ cat > input.ml <<\EOF
   > (* Abstract type for the `document` global *)
   > type document
   > 
-  > external document : document = "document" [@@bs.val]
+  > external document : document = "document"
   > external get_by_id : document -> string -> Dom.element = "getElementById"
-  >   [@@bs.send]
+  >   [@@mel.send]
   > external get_by_classname : Dom.element -> string -> Dom.element
   >   = "getElementsByClassName"
-  >   [@@bs.send]
+  >   [@@mel.send]
   > 
   > let el = document |. get_by_id "my-id" |. get_by_classname "my-class"
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 5, characters 43-54:
+  5 | external get_by_id : document -> string -> Dom.element = "getElementById"
+                                                 ^^^^^^^^^^^
+  Error: Unbound module Dom
+  [1]
 
   $ cat > input.ml <<\EOF
   > (* Abstract type for the `document` global *)
   > type document
   > 
-  > external document : document = "document" [@@bs.val]
+  > external document : document = "document"
   > external get_by_id : string -> Dom.element = "getElementById"
-  >   [@@bs.send.pipe: document]
+  >   [@@mel.send.pipe: document]
   > 
   > let el = get_by_id "my-id" document
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 5, characters 31-42:
+  5 | external get_by_id : string -> Dom.element = "getElementById"
+                                     ^^^^^^^^^^^
+  Error: Unbound module Dom
+  [1]
 
   $ cat > input.ml <<\EOF
   > (* Abstract type for the `document` global *)
   > type document
   > 
-  > external document : document = "document" [@@bs.val]
+  > external document : document = "document"
   > external get_by_id : document -> string -> Dom.element = "getElementById"
-  >   [@@bs.send]
+  >   [@@mel.send]
   > 
   > let el = get_by_id document "my-id"
   > EOF
 
   $ dune build @melange
+  File "input.ml", line 5, characters 43-54:
+  5 | external get_by_id : document -> string -> Dom.element = "getElementById"
+                                                 ^^^^^^^^^^^
+  Error: Unbound module Dom
+  [1]
 
   $ cat > input.ml <<\EOF
   > external draw : x:int -> y:int -> ?border:bool -> unit -> unit = "draw"
@@ -549,7 +579,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > type t
   > 
   > external create : unit -> t = "GUI"
-  >   [@@bs.new] [@@bs.scope "default"] [@@bs.module "dat.gui"]
+  >   [@@mel.new] [@@mel.scope "default"] [@@mel.module "dat.gui"]
   > 
   > let gui = create ()
   > EOF
@@ -557,7 +587,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > external imul : int -> int -> int = "imul" [@@bs.val] [@@bs.scope "Math"]
+  > external imul : int -> int -> int = "imul" [@@mel.scope "Math"]
   > 
   > let res = imul 1 2
   > EOF
@@ -568,7 +598,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > type t
   > 
   > external back : t = "back"
-  >   [@@bs.module "expo-camera"] [@@bs.scope "Camera", "Constants", "Type"]
+  >   [@@mel.module "expo-camera"] [@@mel.scope "Camera", "Constants", "Type"]
   > 
   > let camera_type_back = back
   > EOF
@@ -578,19 +608,19 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > type param
   > external executeCommands : string -> param array -> unit = ""
-  >   [@@bs.scope "commands"] [@@bs.module "vscode"] [@@bs.variadic]
+  >   [@@mel.scope "commands"] [@@mel.module "vscode"] [@@mel.variadic]
   > 
   > let f a b c = executeCommands "hi" [| a; b; c |]
   > EOF
 
   $ dune build @melange
-  File "input.ml", lines 2-3, characters 0-64:
+  File "input.ml", lines 2-3, characters 0-67:
   2 | external executeCommands : string -> param array -> unit = ""
-  3 |   [@@bs.scope "commands"] [@@bs.module "vscode"] [@@bs.variadic]
+  3 |   [@@mel.scope "commands"] [@@mel.module "vscode"] [@@mel.variadic]
   Alert fragile: executeCommands : the external name is inferred from val name is unsafe from refactoring when changing value name
 
   $ cat > input.ml <<\EOF
-  > external dirname : string -> string = "dirname" [@@bs.module "path"]
+  > external dirname : string -> string = "dirname" [@@mel.module "path"]
   > let root = dirname "/User/github"
   > EOF
 
@@ -600,7 +630,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > (* Abstract type for `document` *)
   > type document
   > 
-  > external document : document = "document" [@@bs.val]
+  > external document : document = "document"
   > let document = document
   > EOF
 
@@ -610,8 +640,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > (* Abstract type for `timeoutId` *)
   > type timeoutId
   > external setTimeout : (unit -> unit) -> int -> timeoutId = "setTimeout"
-  >   [@@bs.val]
-  > external clearTimeout : timeoutId -> unit = "clearTimeout" [@@bs.val]
+  > external clearTimeout : timeoutId -> unit = "clearTimeout"
   > 
   > let id = setTimeout (fun () -> Js.log "hello") 100
   > let () = clearTimeout id
@@ -621,7 +650,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > type t
-  > external book : unit -> t = "Book" [@@bs.new] [@@bs.module]
+  > external book : unit -> t = "Book" [@@mel.new] [@@mel.module]
   > let myBook = book ()
   > EOF
 
@@ -629,7 +658,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > type t
-  > external create_date : unit -> t = "Date" [@@bs.new]
+  > external create_date : unit -> t = "Date" [@@mel.new]
   > let date = create_date ()
   > EOF
 
@@ -637,9 +666,9 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > type t
-  > external create : int -> t = "Int32Array" [@@bs.new]
-  > external get : t -> int -> int = "get" [@@bs.get_index]
-  > external set : t -> int -> int -> unit = "set" [@@bs.set_index]
+  > external create : int -> t = "Int32Array" [@@mel.new]
+  > external get : t -> int -> int = "get" [@@mel.get_index]
+  > external set : t -> int -> int -> unit = "set" [@@mel.set_index]
   > 
   > let () =
   >   let i32arr = (create 3) in
@@ -648,9 +677,9 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 3, characters 42-54:
-  3 | external get : t -> int -> int = "get" [@@bs.get_index]
-                                                ^^^^^^^^^^^^
+  File "input.ml", line 3, characters 42-55:
+  3 | external get : t -> int -> int = "get" [@@mel.get_index]
+                                                ^^^^^^^^^^^^^
   Error: @get_index this particular external's name needs to be a placeholder empty string
   [1]
 
@@ -658,10 +687,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > (* Abstract type for the `document` value *)
   > type document
   > 
-  > external document : document = "document" [@@bs.val]
+  > external document : document = "document"
   > 
-  > external set_title : document -> string -> unit = "title" [@@bs.set]
-  > external get_title : document -> string = "title" [@@bs.get]
+  > external set_title : document -> string -> unit = "title" [@@mel.set]
+  > external get_title : document -> string = "title" [@@mel.get]
   > 
   > let current = get_title document
   > let () = set_title document "melange"
@@ -688,7 +717,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   ?options:< .. > ->
   >   unit ->
   >   _ = ""
-  >   [@@bs.obj]
+  >   [@@mel.obj]
   > EOF
 
   $ dune build @melange
@@ -696,14 +725,14 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > let name_extended obj = obj##name ^ " wayne"
   > 
-  > let one = name_extended [%bs.obj { name = "john"; age = 99 }]
-  > let two = name_extended [%bs.obj { name = "jane"; address = "1 infinite loop" }]
+  > let one = name_extended [%mel.obj { name = "john"; age = 99 }]
+  > let two = name_extended [%mel.obj { name = "jane"; address = "1 infinite loop" }]
   > EOF
 
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > let john = [%bs.obj { name = "john"; age = 99 }]
+  > let john = [%mel.obj { name = "john"; age = 99 }]
   > let t = john##name
   > EOF
 
@@ -711,8 +740,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > type t = {
-  >   foo : int; [@bs.as "0"]
-  >   bar : string; [@bs.as "1"]
+  >   foo : int; [@mel.as "0"]
+  >   bar : string; [@mel.as "1"]
   > }
   > 
   > let value = { foo = 7; bar = "baz" }
@@ -722,7 +751,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > type action = {
-  >   type_ : string [@bs.as "type"]
+  >   type_ : string [@mel.as "type"]
   > }
   > 
   > let action = { type_ = "ADD_USER" }
@@ -737,26 +766,26 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   age : int;
   > }
   > 
-  > external john : person = "john" [@@bs.module "MySchool"]
+  > external john : person = "john" [@@mel.module "MySchool"]
   > let john_name = john.name
   > EOF
 
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > external node_env : string = "NODE_ENV" [@@bs.val] [@@bs.scope "process", "env"]
+  > external node_env : string = "NODE_ENV" [@@mel.scope "process", "env"]
   > 
   > let development = "development"
   > let () = if node_env <> development then Js.log "Only in Production"
   > 
-  > let development_inline = "development" [@@bs.inline]
+  > let development_inline = "development" [@@mel.inline]
   > let () = if node_env <> development_inline then Js.log "Only in Production"
   > EOF
 
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > let () = match [%bs.external __filename] with
+  > let () = match [%mel.external __filename] with
   > | Some f -> Js.log f
   > | None -> Js.log "non-node environment"
   > EOF
@@ -764,7 +793,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > let () = match [%bs.external __DEV__] with
+  > let () = match [%mel.external __DEV__] with
   > | Some _ -> Js.log "dev mode"
   > | None -> Js.log "production mode"
   > EOF
@@ -773,26 +802,26 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > let f x y =
-  >   [%bs.debugger];
+  >   [%mel.debugger];
   >   x + y
   > EOF
 
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > [%%bs.raw "var a = 1"]
+  > [%%mel.raw "var a = 1"]
   > EOF
 
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > let f : unit -> int = [%bs.raw "function() {return 1}"]
+  > let f : unit -> int = [%mel.raw "function() {return 1}"]
   > EOF
 
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > let add = [%bs.raw {|
+  > let add = [%mel.raw {|
   >   function(a, b) {
   >     console.log("hello from raw JavaScript!");
   >     return a + b;
@@ -805,7 +834,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > let r = [%bs.re "/b/g"]
+  > let r = [%mel.re "/b/g"]
   > EOF
 
   $ dune build @melange
@@ -959,8 +988,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ cat > input.ml <<\EOF
   > type document
   > 
-  > external document : document = "document" [@@bs.val]
-  > external set_title : document -> string -> unit = "title" [@@bs.set]
+  > external document : document = "document"
+  > external set_title : document -> string -> unit = "title" [@@mel.set]
   > EOF
 
   $ dune build @melange
@@ -986,20 +1015,16 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > external clearTimeout : timeoutId -> unit = "clearTimeout" [@@bs.val]
+  > type document
+  > external setTitleDom : document -> string -> unit = "title" [@@mel.set]
   > 
   > type t = {
-  >   age : int; [@bs.as "a"]
-  >   name : string; [@bs.as "n"]
+  >   age : int; [@mel.as "a"]
+  >   name : string; [@mel.as "n"]
   > }
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 24-33:
-  1 | external clearTimeout : timeoutId -> unit = "clearTimeout" [@@bs.val]
-                              ^^^^^^^^^
-  Error: Unbound type constructor timeoutId
-  [1]
 
   $ cat > input.ml <<\EOF
   > type name =
@@ -1010,8 +1035,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > [%%bs.raw "var a = 1; var b = 2"]
-  > let add = [%bs.raw "a + b"]
+  > [%%mel.raw "var a = 1; var b = 2"]
+  > let add = [%mel.raw "a + b"]
   > EOF
 
   $ dune build @melange

--- a/scripts/communicate-with-javascript.t
+++ b/scripts/communicate-with-javascript.t
@@ -394,45 +394,24 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > 
   > external document : document = "document" [@@bs.val]
   > external get_by_id : document -> string -> Dom.element = "getElementById"
-  >   [@@bs.send]
+  > [@@mel.send]
   > external style : Dom.element -> style = "style" [@@bs.get]
   > external transition_timing_function :
   >   style ->
-  >   [ `ease
-  >   | `easeIn [@bs.as "ease-in"]
-  >   | `easeOut [@bs.as "ease-out"]
-  >   | `easeInOut [@bs.as "ease-in-out"]
-  >   | `linear
-  >   ] ->
+  >   ([ `ease
+  >    | `easeIn [@mel.as "ease-in"]
+  >    | `easeOut [@mel.as "ease-out"]
+  >    | `easeInOut [@mel.as "ease-in-out"]
+  >    | `linear ]
+  >   [@mel.string]) ->
   >   unit = "transitionTimingFunction"
-  >   [@@bs.set]
+  > [@@mel.set]
   > 
   > let element_style = style (get_by_id document "my-id")
   > let () = transition_timing_function element_style `easeIn
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 11, characters 14-19:
-  11 |   | `easeIn [@bs.as "ease-in"]
-                     ^^^^^
-  Alert unused: Unused attribute [@bs.as]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 12, characters 15-20:
-  12 |   | `easeOut [@bs.as "ease-out"]
-                      ^^^^^
-  Alert unused: Unused attribute [@bs.as]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 13, characters 17-22:
-  13 |   | `easeInOut [@bs.as "ease-in-out"]
-                        ^^^^^
-  Alert unused: Unused attribute [@bs.as]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
 
   $ cat > input.ml <<\EOF
   > external read_file_sync :

--- a/scripts/communicate-with-javascript.t
+++ b/scripts/communicate-with-javascript.t
@@ -31,24 +31,17 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   name : string;
   >   age : int;
   > }
-  > [@@bs.deriving abstract]
+  > [@@deriving abstract]
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 3-14:
-  5 | [@@bs.deriving abstract]
-         ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
 
   $ cat > input.ml <<\EOF
   > type person = {
   >   name : string;
   >   mutable age : int;
   > }
-  > [@@bs.deriving abstract]
+  > [@@deriving abstract]
   > 
   > let alice = person ~name:"Alice" ~age:20
   > 
@@ -56,42 +49,23 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 3-14:
-  5 | [@@bs.deriving abstract]
-         ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 7, characters 12-18:
-  7 | let alice = person ~name:"Alice" ~age:20
-                  ^^^^^^
-  Error: Unbound value person
-  [1]
 
   $ cat > input.ml <<\EOF
   > type person = {
   >   name : string;
   >   age : int;
   > }
-  > [@@bs.deriving { abstract = light }]
+  > [@@deriving { abstract = light }]
   > 
   > let alice = person ~name:"Alice" ~age:20
   > let aliceName = name alice
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 3-14:
-  5 | [@@bs.deriving { abstract = light }]
-         ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 7, characters 12-18:
-  7 | let alice = person ~name:"Alice" ~age:20
-                  ^^^^^^
-  Error: Unbound value person
+  File "input.ml", line 5, characters 12-32:
+  5 | [@@deriving { abstract = light }]
+                  ^^^^^^^^^^^^^^^^^^^^
+  Error: tuple expected
   [1]
 
   $ cat > input.ml <<\EOF
@@ -169,7 +143,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > type pet = { name : string } [@@bs.deriving accessors]
+  > type pet = { name : string } [@@deriving accessors]
   > 
   > let pets = [| { name = "Brutus" }; { name = "Mochi" } |]
   > 
@@ -177,18 +151,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 32-43:
-  1 | type pet = { name : string } [@@bs.deriving accessors]
-                                      ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 5, characters 32-36:
-  5 | let () = pets |. Belt.Array.map name |. Js.Array2.joinWith "&" |. Js.log
-                                      ^^^^
-  Error: Unbound value name
-  [1]
 
   $ cat > input.ml <<\EOF
   > val actionToJs : action -> string
@@ -210,24 +172,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   | `Submit [@bs.as "submit"]
   >   | `Cancel
   >   ]
-  > [@@bs.deriving jsConverter]
+  > [@@deriving jsConverter]
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 3, characters 14-19:
-  3 |   | `Submit [@bs.as "submit"]
-                    ^^^^^
-  Alert unused: Unused attribute [@bs.as]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 6, characters 3-14:
-  6 | [@@bs.deriving jsConverter]
-         ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
 
   $ cat > input.ml <<\EOF
   > val actionToJs : action -> abs_action
@@ -248,24 +196,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   | Click
   >   | Submit [@bs.as 3]
   >   | Cancel
-  > [@@bs.deriving { jsConverter = newType }]
+  > [@@deriving jsConverter {  newType }]
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 3, characters 13-18:
-  3 |   | Submit [@bs.as 3]
-                   ^^^^^
-  Alert unused: Unused attribute [@bs.as]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 5, characters 3-14:
-  5 | [@@bs.deriving { jsConverter = newType }]
-         ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
 
   $ cat > input.ml <<\EOF
   > val actionToJs : action -> int
@@ -286,24 +220,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   | Click
   >   | Submit [@bs.as 3]
   >   | Cancel
-  > [@@bs.deriving jsConverter]
+  > [@@deriving jsConverter]
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 3, characters 13-18:
-  3 |   | Submit [@bs.as 3]
-                   ^^^^^
-  Alert unused: Unused attribute [@bs.as]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 5, characters 3-14:
-  5 | [@@bs.deriving jsConverter]
-         ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
 
   $ cat > input.ml <<\EOF
   > type action =
@@ -323,17 +243,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   | Click
   >   | Submit of string
   >   | Cancel
-  > [@@bs.deriving accessors]
+  > [@@deriving accessors]
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 3-14:
-  5 | [@@bs.deriving accessors]
-         ^^^^^^^^^^^
-  Alert unused: Unused attribute [@bs.deriving]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
 
   $ cat > input.ml <<\EOF
   > type element

--- a/scripts/communicate-with-javascript.t
+++ b/scripts/communicate-with-javascript.t
@@ -10,7 +10,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > (melange.emit
   >  (emit_stdlib false)
   >  (target output)
-  >  (libraries melange.node)
+  >  (libraries melange.dom melange.node)
   >  (preprocess (pps melange.ppx)))
   > EOF
 
@@ -407,11 +407,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 43-54:
-  5 | external get_by_id : document -> string -> Dom.element = "getElementById"
-                                                 ^^^^^^^^^^^
-  Error: Unbound module Dom
-  [1]
 
   $ cat > input.ml <<\EOF
   > external read_file_sync :
@@ -483,11 +478,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 31-42:
-  5 | external get_by_id : string -> Dom.element = "getElementById"
-                                     ^^^^^^^^^^^
-  Error: Unbound module Dom
-  [1]
 
   $ cat > input.ml <<\EOF
   > (* Abstract type for the `document` global *)
@@ -504,11 +494,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 43-54:
-  5 | external get_by_id : document -> string -> Dom.element = "getElementById"
-                                                 ^^^^^^^^^^^
-  Error: Unbound module Dom
-  [1]
 
   $ cat > input.ml <<\EOF
   > (* Abstract type for the `document` global *)
@@ -522,11 +507,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 31-42:
-  5 | external get_by_id : string -> Dom.element = "getElementById"
-                                     ^^^^^^^^^^^
-  Error: Unbound module Dom
-  [1]
 
   $ cat > input.ml <<\EOF
   > (* Abstract type for the `document` global *)
@@ -540,11 +520,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 43-54:
-  5 | external get_by_id : document -> string -> Dom.element = "getElementById"
-                                                 ^^^^^^^^^^^
-  Error: Unbound module Dom
-  [1]
 
   $ cat > input.ml <<\EOF
   > external draw : x:int -> y:int -> ?border:bool -> unit -> unit = "draw"

--- a/scripts/extract_code_blocks.ml
+++ b/scripts/extract_code_blocks.ml
@@ -97,7 +97,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > (melange.emit
   >  (emit_stdlib false)
   >  (target output)
-  >  (libraries melange.node)
+  >  (libraries melange.dom melange.node)
   >  (preprocess (pps melange.ppx)))
   > EOF
 |};


### PR DESCRIPTION
Fixes #75.
Fixes #102.

- Updates switch to OCaml 5
- Updates melange, melange-playground, reason, and reason-react to latest
- Updates docs refs to `bs` -> `mel` or `u`
- Fix some of the tests