### PR TITLE
playground: fix onload error markers

### DIFF
--- a/playground/src/app.jsx
+++ b/playground/src/app.jsx
@@ -443,6 +443,21 @@ const compile = (language, code) => {
   }
 };
 
+function updateMarkers(monaco, editorRef, compilation) {
+  if (monaco && editorRef.current) {
+    const owner = "playground";
+    if (compilation?.problems) {
+      monaco.editor.setModelMarkers(
+        editorRef.current.getModel(),
+        owner,
+        compilation.problems.map(toMonaco)
+      );
+    } else {
+      monaco.editor.removeAllMarkers(owner);
+    }
+  }
+}
+
 function App() {
   const defaultState = {
     language: languageMap.OCaml,
@@ -467,8 +482,9 @@ function App() {
 
   const editorRef = React.useRef(null);
 
-  function handleEditorDidMount(editor, _monaco) {
+  function handleEditorDidMount(editor, monaco) {
     editorRef.current = editor;
+    updateMarkers(monaco, editorRef, compilation);
   }
 
   function clearLogs() {
@@ -489,19 +505,7 @@ function App() {
   }, [monaco]);
 
   React.useEffect(() => {
-    // or make sure that it exists by other ways
-    if (monaco && editorRef.current) {
-      const owner = "playground";
-      if (compilation?.problems) {
-        monaco.editor.setModelMarkers(
-          editorRef.current.getModel(),
-          owner,
-          compilation.problems.map(toMonaco)
-        );
-      } else {
-        monaco.editor.removeAllMarkers(owner);
-      }
-    }
+    updateMarkers(monaco, editorRef, compilation)
   }, [monaco, compilation?.problems]);
 
   React.useEffect(() => {


### PR DESCRIPTION
The error markers were not showing on playground load because the `editorRef.current` was not assigned yet.