### PR TITLE
Fix mike error with pkg_resources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix-mike
     tags-ignore:
       - 'v*'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix-mike
     tags-ignore:
       - 'v*'
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.4.3
 mkdocs-print-site-plugin==2.3.4
-mike==1.1.2
+mike @ git+https://github.com/jchavarri/mike@1.1.2-with-importlib


### PR DESCRIPTION
Recent deploys [fail](https://github.com/melange-re/melange-re.github.io/actions/runs/6664631116/job/18112630832#step:18:23) with:

```
 Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.0/x64/bin/mike", line 5, in <module>
    from mike.driver import main
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/mike/driver.py", line 4, in <module>
    from . import arguments, commands
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/mike/commands.py", line 6, in <module>
    from pkg_resources import resource_stream
ModuleNotFoundError: No module named 'pkg_resources'
```

It seems a patch was [applied](https://github.com/jimporter/mike/commit/063c93e9cce7c82939c7d47e6d33f99b24bba372) upstream, but a new version of mike hasn't been released yet. So I just forked the repo, [cherry picked the patch](https://github.com/jchavarri/mike/commit/80db933a1181cb028010c783184ec5ab4abd421b, and pin pip-requirements to it.

## TODO

- [x] remove this branch from ci job spec