### PR TITLE
Prepare for new version 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,36 @@ dune build @re --auto-promote
 
 Publishing is done automatically from GitHub actions:
 - Every commit to `master` will publish in the `unstable` folder
-- Every tag pushed with the `v*` format will publish on its correponding folder,
-  and set it as default
+- Every tag pushed with the `v*` format will publish on its corresponding
+  folder, and set it as default
+
+### Tracking new versions of `melange` in opam
+
+When a new version of `melange` is published in opam, a new release of the docs
+and playground should be done. The process is as follows:
+
+- Update `documentation-site.opam` to point `melange` and `melange-playground`
+  packages to the commit of the new release
+- Update versions of the compiler listed in the playground (`app.jsx`)
+- Open a PR with the changes above
+- After merging the PR, create a new branch `x.x.x-patches`. This branch will be
+  used to publish any patches or improvements to that version of the docs /
+  playground
+- In that branch, add a new command on the main `Makefile` to publish a new tag,
+  e.g.
+```Makefile
+.PHONY: move-vx.x.x-tag
+move-vx.x.x-tag: ## Moves the vx.x.x tag to the latest commit, useful to publish the vx docs
+	git push origin :refs/tags/vx.x.x
+	git tag -fa vx.x.x
+	git push origin --tags
+```
+- Call the newly created command to create a new version selectable from the
+  website: `make move-vx.x.x-tag`
+- Once the new version is published, we need to make sure other versions remain
+  SEO friendly:
+  - Update `add_canonical` in `master` to point to the new `vx.x.x`, so that the
+    `unstable` version of the docs starts referring to that version as the
+    canonical one
+  - Update `add_canonical` in version that was last before, to point to `vx.x.x`
+    as well

--- a/documentation-site.opam
+++ b/documentation-site.opam
@@ -16,8 +16,8 @@ depends: [
   "ocaml"
   "dune" {>= "3.8.0"}
   "reason" {>= "3.10.0"}
-  "reason-react" {dev}
-  "reason-react-ppx" {dev}
+  "reason-react"
+  "reason-react-ppx"
   "ocamlformat"
   "js_of_ocaml"
   "cmarkit" {dev}
@@ -27,10 +27,8 @@ depends: [
 ]
 dev-repo: "git+https://github.com/melange-re/melange-re.github.io.git"
 pin-depends: [
-  [ "reason-react.dev" "git+https://github.com/reasonml/reason-react.git#0ccff71796b60d6c32ab6cf01e31beccca4698b9" ]
-  [ "reason-react-ppx.dev" "git+https://github.com/reasonml/reason-react.git#0ccff71796b60d6c32ab6cf01e31beccca4698b9" ]
-  [ "melange.dev" "git+https://github.com/melange-re/melange.git#616bbdf89fa45018dbc625cd4c1073303700304f" ]
-  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#616bbdf89fa45018dbc625cd4c1073303700304f" ]
+  [ "melange.dev" "git+https://github.com/melange-re/melange.git#e565471cdb086cc3632687366d8ea503d5da39e7" ]
+  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#e565471cdb086cc3632687366d8ea503d5da39e7" ]
   [ "cmarkit.dev" "git+https://github.com/dbuenzli/cmarkit.git#f37c8ea86fd0be8dba7a8babcee3682e0e047d91" ]
 ]
 build: [

--- a/playground/src/app.jsx
+++ b/playground/src/app.jsx
@@ -137,7 +137,7 @@ function Sidebar({ onExampleClick }) {
             <div className="Versions">
               <span className="Version">
                 <span className="Text-xs">{"Melange"}</span>
-                <span className="Text-xs Number">{"dev"}</span>
+                <span className="Text-xs Number">{"2.1.0"}</span>
               </span>
               <span className="Version">
                 <span className="Text-xs">{"OCaml"}</span>
@@ -146,6 +146,10 @@ function Sidebar({ onExampleClick }) {
               <span className="Version">
                 <span className="Text-xs">{"Reason"}</span>
                 <span className="Text-xs Number">{"3.10.0"}</span>
+              </span>
+              <span className="Version">
+                <span className="Text-xs">{"ReasonReact"}</span>
+                <span className="Text-xs Number">{"0.13.0"}</span>
               </span>
             </div>
           </div>) : null}


### PR DESCRIPTION
Prepares a release of the docs + playground for 2.1.0, published [recently](https://opam.ocaml.org/packages/melange/).

Includes some instructions to detail how to prepare this kind of releases, that I will try to follow after merging, to make sure they are accurate 😄 