### PR TITLE
Prepare release OCaml 5.1.1, Melange 2.2.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - run: python3 -m pip install -r ./pip-requirements.txt
       - uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.1.x
+          ocaml-compiler: 5.1.1
           dune-cache: false # can cause trouble when generating melange docs in step below: https://github.com/ocaml/dune/issues/7720
       - name: Install all deps
         run: make install

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -16,7 +16,7 @@ jobs:
       - run: python3 -m pip install -r ./pip-requirements.txt
       - uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.1.x
+          ocaml-compiler: 5.1.1
           dune-cache: false # can cause trouble when generating melange docs in step below: https://github.com/ocaml/dune/issues/7720
       - name: Install all deps
         run: make install

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Print this help message
 
 .PHONY: create-switch
 create-switch: ## Create opam switch
-	opam switch create . 5.1.0 -y --deps-only
+	opam switch create . 5.1.1 -y --deps-only
 
 .PHONY: init
 init: create-switch install ## Configure everything to develop this repository in local

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -65,7 +65,7 @@ First of all, create an opam switch, as shown in the [package management
 section](package-management.md):
 
 ```bash
-opam switch create . 5.1.0 --deps-only
+opam switch create . 5.1.1 --deps-only
 ```
 
 Install the latest versions of Dune and Melange in the switch:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ For Visual Studio Code, install the [OCaml Platform Visual Studio Code
 extension](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform)
 from the Visual Studio Marketplace. When you load an OCaml source file for the
 first time, you may be prompted to select the toolchain to use. Select the
-version of OCaml you are using from the list, such as 5.1.0. Further
+version of OCaml you are using from the list, such as 5.1.1. Further
 instructions for configuration can be found in the [extension
 repository](https://github.com/ocamllabs/vscode-ocaml-platform#setting-up-the-extension-for-your-project).
 

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -59,7 +59,7 @@ switch](https://opam.ocaml.org/blog/opam-local-switches/) to start working on
 our library:
 
 ```bash
-opam switch create . 5.1.0 -y --deps-only
+opam switch create . 5.1.1 -y --deps-only
 ```
 
 Once this step is done, we can call `dune` from the library folder, but first we
@@ -449,7 +449,7 @@ opam update
 Now, update the version of the OCaml compiler in the local switch to 5.1:
 
 ```bash
-opam install --update-invariant ocaml-base-compiler.5.1.0
+opam install --update-invariant ocaml-base-compiler.5.1.1
 ```
 
 Finally, we can upgrade all packages to get Melange v2 and the latest version of
@@ -466,7 +466,7 @@ subcommand:
 opam list --installed melange
 # Packages matching: name-match(melange) & installed
 # Name  # Installed    # Synopsis
-melange 2.0.0          Toolchain to produce JS from Reason/OCaml
+melange 2.2.0          Toolchain to produce JS from Reason/OCaml
 ```
 
 Before building, we have to update some parts of the configuration to make it

--- a/docs/melange-for-x-developers.md
+++ b/docs/melange-for-x-developers.md
@@ -581,7 +581,7 @@ architectures are not included in the pre-built binaries.
 ### OCaml compiler version
 
 ReScript is compatible with the 4.06 version of the OCaml compiler, while
-Melange is compatible with the version 5.1.0 (as of Oct 2023).
+Melange is compatible with the version 5.1.1 (as of Dec 2023).
 
 ### Editor integration
 

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -158,7 +158,7 @@ in the project folder.
 If it does not exist, we can create it with:
 
 ```text
-opam switch create . 5.1.0 --deps-only
+opam switch create . 5.1.1 --deps-only
 ```
 
 If it exists, we can install the dependencies of the project with:

--- a/documentation-site.opam
+++ b/documentation-site.opam
@@ -27,10 +27,8 @@ depends: [
 ]
 dev-repo: "git+https://github.com/melange-re/melange-re.github.io.git"
 pin-depends: [
-  [ "melange.dev" "git+https://github.com/melange-re/melange.git#251e0d3e0d020e0a6670375da2db6284ec0627bd" ]
-  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#251e0d3e0d020e0a6670375da2db6284ec0627bd" ]
-  [ "reason-react.dev" "git+https://github.com/reasonml/reason-react.git#18a8fa2b3524b5f5cf0154875f963db096a992e9" ]
-  [ "reason-react-ppx.dev" "git+https://github.com/reasonml/reason-react.git#18a8fa2b3524b5f5cf0154875f963db096a992e9" ]
+  [ "melange.dev" "git+https://github.com/melange-re/melange.git#97ebd7d3d3f8fb66dbbf4df6691b0cf4b95dc153" ]
+  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#97ebd7d3d3f8fb66dbbf4df6691b0cf4b95dc153" ]
   [ "cmarkit.dev" "git+https://github.com/dbuenzli/cmarkit.git#f37c8ea86fd0be8dba7a8babcee3682e0e047d91" ]
 ]
 build: [

--- a/playground/src/app.jsx
+++ b/playground/src/app.jsx
@@ -137,11 +137,11 @@ function Sidebar({ onExampleClick }) {
             <div className="Versions">
               <span className="Version">
                 <span className="Text-xs">{"Melange"}</span>
-                <span className="Text-xs Number">{"dev"}</span>
+                <span className="Text-xs Number">{"2.2.0"}</span>
               </span>
               <span className="Version">
                 <span className="Text-xs">{"OCaml"}</span>
-                <span className="Text-xs Number">{"5.1.0"}</span>
+                <span className="Text-xs Number">{"5.1.1"}</span>
               </span>
               <span className="Version">
                 <span className="Text-xs">{"Reason"}</span>
@@ -149,7 +149,7 @@ function Sidebar({ onExampleClick }) {
               </span>
               <span className="Version">
                 <span className="Text-xs">{"ReasonReact"}</span>
-                <span className="Text-xs Number">{"dev"}</span>
+                <span className="Text-xs Number">{"0.13.0"}</span>
               </span>
             </div>
           </div>) : null}


### PR DESCRIPTION
Frst part of the Melange 2.2.0 docs release. Next part will be the long-standing branch + tag for proper release.