### PR TITLE
Remove rollup treeshake

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: "../docs/playground",
+    rollupOptions: {
+      treeshake: false
+    }
   },
   base: "./",
 });


### PR DESCRIPTION
There's a bug in rollup that prevents us to bundle the melange compiler and ocamlformat, see https://github.com/ocsigen/js_of_ocaml/issues/1547 and https://github.com/rollup/rollup/issues/5292.

For now disabling treeshaking, I briefly tried removing vite and use just esbuild but ran into a bunch of separate issues.