### PR TITLE
Prepare release Melange 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ When a new version of `melange` is published in opam, a new release of the docs
 and playground should be published. The process is as follows:
 
 - Update `documentation-site.opam` to point `melange` and `melange-playground`
-  packages to the commit of the new release
+  packages to the commit of the new release (they need to be pinned so that the
+  Melange docs can be accessed on a stable path)
 - Update versions of the compiler listed in the playground (`app.jsx`)
+- In the docs markdown pages, grep for the last version of Melange that was used
+  and replace it with the newer one.
 - Open a PR with the changes above
 - After merging the PR, create a new branch `x.x.x-patches`. This branch will be
   used to publish any patches or improvements to that version of the docs /
@@ -91,8 +94,8 @@ move-vx.x.x-tag: ## Moves the vx.x.x tag to the latest commit, useful to publish
       - update the version in `add_canonical.ml`
       - run `dune test --auto-promote`
       - uncomment the relevant code in `deploy.yml`
-- Finally, we need to disable the publication of previous version `y.y.y` as
-  the default version:
+- Finally, we need to disable the publication of previous version `y.y.y` as the
+  default version:
   - In `y.y.y-patches`: update `publish-version.yml` so that `mike deploy -push`
     is used and `set-default` is removed.
   - Commit and run `make move-vy.y.y-tag` to deploy

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -466,7 +466,7 @@ subcommand:
 opam list --installed melange
 # Packages matching: name-match(melange) & installed
 # Name  # Installed    # Synopsis
-melange 2.2.0          Toolchain to produce JS from Reason/OCaml
+melange 3.0.0          Toolchain to produce JS from Reason/OCaml
 ```
 
 Before building, we have to update some parts of the configuration to make it

--- a/documentation-site.opam
+++ b/documentation-site.opam
@@ -27,8 +27,8 @@ depends: [
 ]
 dev-repo: "git+https://github.com/melange-re/melange-re.github.io.git"
 pin-depends: [
-  [ "melange.dev" "git+https://github.com/melange-re/melange.git#1a1f87a209f9677883563af24a99384219e07313" ]
-  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#1a1f87a209f9677883563af24a99384219e07313" ]
+  [ "melange.dev" "git+https://github.com/melange-re/melange.git#766b65d21dbe60fbcab74d458395606c2676d2bd" ]
+  [ "melange-playground.dev" "git+https://github.com/melange-re/melange.git#766b65d21dbe60fbcab74d458395606c2676d2bd" ]
   [ "reason-react.dev" "git+https://github.com/reasonml/reason-react.git#4ee2eda353628090eda95e0b8dabe4e2be50f954" ]
   [ "reason-react-ppx.dev" "git+https://github.com/reasonml/reason-react.git#4ee2eda353628090eda95e0b8dabe4e2be50f954" ]
   [ "cmarkit.dev" "git+https://github.com/dbuenzli/cmarkit.git#f37c8ea86fd0be8dba7a8babcee3682e0e047d91" ]

--- a/playground/src/app.jsx
+++ b/playground/src/app.jsx
@@ -137,7 +137,7 @@ function Sidebar({ onExampleClick }) {
             <div className="Versions">
               <span className="Version">
                 <span className="Text-xs">{"Melange"}</span>
-                <span className="Text-xs Number">{"dev"}</span>
+                <span className="Text-xs Number">{"3.0.0-51"}</span>
               </span>
               <span className="Version">
                 <span className="Text-xs">{"OCaml"}</span>


### PR DESCRIPTION
Frst part of the Melange 3.0.0 docs release. Next part will be the long-standing branch + tag for proper release.