### PR TITLE
fix scroll to location hash

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,6 +2,8 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { defineConfig } from "vitepress";
 
+const toggleSyntaxScript = readFileSync(join(__dirname, './toggleSyntax.js'), 'utf8');
+
 // From https://github.com/ocamllabs/vscode-ocaml-platform/blob/master/syntaxes/reason.json
 const reasonGrammar = JSON.parse(
   readFileSync(join(__dirname, "./reasonml.tmLanguage.json"), "utf8")
@@ -12,6 +14,13 @@ const base = process.env.BASE || "unstable";
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Melange Documentation Site",
+  head:[
+    [
+      'script',
+      {},
+      toggleSyntaxScript
+    ]
+  ],
   description:
     "The official documentation site for Melange, a compiler from OCaml to JavaScript. Explore the features and resources for functional programming with Melange, including the standard libraries APIs, the playground, and extensive documentation about bindings, build system, and the opam package manager.",
   base: `/${base}/`,

--- a/docs/.vitepress/toggleSyntax.js
+++ b/docs/.vitepress/toggleSyntax.js
@@ -1,0 +1,19 @@
+// Keep in sync with Switch.vue
+// Just needed so that Vitepress finds the content already in the right
+// position when it scrolls to location hash
+document.addEventListener("DOMContentLoaded", () => {
+    const SYNTAXES = ["reasonml", "ocaml"];
+    const CLASS_PREFIX = "syntax__";
+    let currentSyntax;
+    let setCurrentSyntax = (syntax = SYNTAXES[0]) => {
+        document.body.classList.remove(`${CLASS_PREFIX}${currentSyntax}`);
+        document.body.classList.add(`${CLASS_PREFIX}${syntax}`);
+
+        currentSyntax = syntax;
+        localStorage.setItem("syntax", currentSyntax);
+    };
+
+    setCurrentSyntax(
+        localStorage.getItem("syntax", currentSyntax) || SYNTAXES[0]
+    );
+});


### PR DESCRIPTION
Currently, the scroll to location hash is broken due to vitepress doing the scroll before the `Switch.vue` component has had time to update the global classes that control the visibility of `reason` and `ocaml` blocks.

The PR adds a small script that mostly reproduces what `Switch.vue` is doing, but does so after `DOMContentLoaded` event, so when vitepress runs the scroll to hash logic, the content is already in its right position.

cc @feihong