### PR TITLE
(Example) Expose `routes` library in playground

### DIFF
--- a/documentation-site.opam
+++ b/documentation-site.opam
@@ -18,6 +18,7 @@ depends: [
   "reason" {>= "3.10.0"}
   "reason-react"
   "reason-react-ppx"
+  "routes"
   "ocamlformat"
   "js_of_ocaml"
   "cmarkit" {dev}
@@ -32,6 +33,7 @@ pin-depends: [
   [ "reason-react.dev" "git+https://github.com/reasonml/reason-react.git#4ee2eda353628090eda95e0b8dabe4e2be50f954" ]
   [ "reason-react-ppx.dev" "git+https://github.com/reasonml/reason-react.git#4ee2eda353628090eda95e0b8dabe4e2be50f954" ]
   [ "cmarkit.dev" "git+https://github.com/dbuenzli/cmarkit.git#f37c8ea86fd0be8dba7a8babcee3682e0e047d91" ]
+  [ "routes.dev" "git+https://github.com/jchavarri/routes.git#57fb76038b429a6adb4e42aeef04cca7079fe157" ]
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/playground/dune
+++ b/playground/dune
@@ -6,7 +6,8 @@
   ; melange doesn't include belt and dom anymore, including them below leads to
   ; `_build/default/playground/output/node_modules` to include the runtimes
   melange.belt
-  melange.dom)
+  melange.dom
+  routes)
  (modules) ; Empty, we just want to the js artifacts from the libraries
  (module_systems es6))
 
@@ -15,6 +16,15 @@
   %{bin:js_of_ocaml}
   (:some-cmi %{lib:reason-react:melange/react.cmi}))
  (target reason-react-cmijs.js)
+ (action
+  (bash
+   "find $(dirname %{some-cmi}) -name \"*.cmi\" -or -name \"*.cmj\" | xargs js_of_ocaml build-fs -o %{target}")))
+
+(rule
+ (deps
+  %{bin:js_of_ocaml}
+  (:some-cmi %{lib:routes:melange/routes.cmi}))
+ (target routes-cmijs.js)
  (action
   (bash
    "find $(dirname %{some-cmi}) -name \"*.cmi\" -or -name \"*.cmj\" | xargs js_of_ocaml build-fs -o %{target}")))
@@ -37,6 +47,7 @@
  (deps
   (alias playground-runtime-js)
   format.bc.js
-  reason-react-cmijs.js)
+  reason-react-cmijs.js
+  routes-cmijs.js)
  (action
   (echo "assets generated")))

--- a/playground/src/app.jsx
+++ b/playground/src/app.jsx
@@ -1,5 +1,6 @@
 import "./App.css";
 import "../../_build/default/playground/reason-react-cmijs";
+import "../../_build/default/playground/routes-cmijs";
 import "../../_opam/bin/mel_playground.bc";
 import "../../_opam/bin/melange-cmijs";
 import "../../_opam/bin/format.bc.js";


### PR DESCRIPTION
This is just a small example based on a [Twitter convo](https://twitter.com/ManasJayanth/status/1782603168213299440) with @ManasJayanth about exposing "regular" OCaml libraries in the playground.

The changes required are the following:
- The libraries added need to be compatible with Melange. See the related PR in routes repo: https://github.com/anuragsoni/routes/pull/151
- Add the package to the doc site opam file
- Add the libraries to the playground `melange.emit` stanza. This makes sure that the generated JS files will be available in `node_modules` for bundling
- Add a Dune rule to generate the `cmijs` from the library so they can be compiled "live" in the playground. Add this `cmijs.js` file to both the `playground-assets` and the `app.jsx` entry point so they get loaded in the browser.

And a screen capture:

<img width="1211" alt="image" src="https://github.com/melange-re/melange-re.github.io/assets/220424/822eba06-0fae-412a-8710-a3f7a2698a19">
