### PR TITLE
Fix dune docs links

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -46,7 +46,7 @@ developers. It provides several benefits, including:
 - Hygiene is maintained in Dune by building out of source: all compilation
   artifacts are placed in a separate `_build` folder. Users can optionally [copy
   them back to the source
-  tree](https://dune.readthedocs.io/en/stable/dune-files.html#promote).
+  tree](https://dune.readthedocs.io/en/stable/reference/dune/rule.html#promote).
 - Dune provides a variety of additional features including [cram
   tests](https://dune.readthedocs.io/en/stable/tests.html), integration with
   [Odoc](https://dune.readthedocs.io/en/stable/documentation.html), Melange,
@@ -98,7 +98,7 @@ only available from version 3.8.
 
 The second line `(using melange 0.1)` tells Dune we want to use the [Melange
 extension of the Dune
-language](https://dune.readthedocs.io/en/stable/dune-files.html#using).
+language](https://dune.readthedocs.io/en/stable/reference/dune-project/using.html).
 
 #### Adding a library
 
@@ -131,7 +131,7 @@ The top level configuration entries —like the `library` one that appears in th
 
 All stanzas are well covered in the Dune documentation site, where we can find
 the reference for the [`library`
-stanza](https://dune.readthedocs.io/en/stable/dune-files.html#library).
+stanza](https://dune.readthedocs.io/en/stable/reference/dune/library.html).
 
 Dune is designed to minimize the need for configuration changes when modifying
 the project folder structure. For example, you can move the `lib` folder to a

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,7 +133,7 @@ To enter a Melange development shell, run `nix develop -c $SHELL`.
 #### [esy](https://esy.sh/)
 
 First, make sure `esy` is
-[installed](https://esy.sh/docs/en/getting-started.html#install-esy). `npm i -g
+[installed](https://esy.sh/docs/getting-started#install-esy). `npm i -g
 esy` does the trick in most setups.
 
 The following is an example `esy.json` that can help start a Melange project. A

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -94,7 +94,8 @@ Let's see how the most common configurations in `bsconfig.json` (or
 `rescript.json`) map to `dune` files. You can find more information about these
 configurations in the [Rescript
 docs](https://rescript-lang.org/docs/manual/latest/build-configuration) and in
-the [Dune docs](https://dune.readthedocs.io/en/stable/dune-files.html#library).
+the [Dune
+docs](https://dune.readthedocs.io/en/stable/reference/dune/library.html).
 
 #### `name`, `namespace`
 
@@ -136,11 +137,11 @@ include just the files inside that folder to the library itself (unless the
 subfolders in it, you can use the following combination of stanzas:
 
 - `(include_subdirs unqualified)`
-  ([docs](https://dune.readthedocs.io/en/stable/dune-files.html#include-subdirs)):
+  ([docs](https://dune.readthedocs.io/en/stable/reference/dune/include_subdirs.html)):
   This stanza tells Dune to look for sources in all the subfolders of the folder
   where the `dune` file lives.
 - `(dirs foo bar)`
-  ([docs](https://dune.readthedocs.io/en/stable/dune-files.html#dirs)): This
+  ([docs](https://dune.readthedocs.io/en/stable/reference/dune/dirs.html)): This
   stanza tells Dune to only look into `foo` and `bar` subdirectories of the
   current folder.
 
@@ -261,7 +262,7 @@ This could be expressed in a `dune` file with something like:
 ```
 
 To read more about Dune rules, check [the
-documentation](https://dune.readthedocs.io/en/stable/dune-files.html#rule).
+documentation](https://dune.readthedocs.io/en/stable/reference/dune/rule.html).
 
 #### `package-specs`
 
@@ -273,7 +274,7 @@ system](./build-system.md#commonjs-or-es6-modules) section.
 Regarding the `"in-source"` configuration, the corresponding field in Dune would
 be the `(promote (until-clean))` configuration, which can be added to a
 `melange.emit` stanza. You can read more about it in [the Dune
-documentation](https://dune.readthedocs.io/en/stable/dune-files.html#promote).
+documentation](https://dune.readthedocs.io/en/stable/reference/dune/rule.html#promote).
 
 #### `suffix`
 

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -410,8 +410,8 @@ still useful, compatible BuckleScript libraries can be found on npm, e.g.,
 record it in the `package.json` file at the root of our project.
 
 Dune needs to be made aware of the newly installed package. The
-[`subdir`](https://dune.readthedocs.io/en/stable/dune-files.html#subdir) stanza
-can be handy in these cases:
+[`subdir`](https://dune.readthedocs.io/en/stable/reference/dune/subdir.html)
+stanza can be handy in these cases:
 
 ```text
 (subdir


### PR DESCRIPTION
Dune docs recently changed their layout breaking some existing links. Same with esy docs.

Broken links found using [Ahrefs Site Audit](https://ahrefs.com/site-audit).