### PR TITLE
open github sidebar link on a separate tab

### DIFF
--- a/theme/versions.html
+++ b/theme/versions.html
@@ -1,7 +1,7 @@
 <div class="rst-versions" role="note" aria-label="{% trans %}Versions{% endtrans %}">
     <span class="rst-current-version" data-toggle="rst-current-version">
         <span>
-            <a href="https://github.com/melange-re/melange" class="fa fa-github" style="color: #fcfcfc"> GitHub</a>
+            <a href="https://github.com/melange-re/melange" target="_blank" class="fa fa-github" style="color: #fcfcfc"> GitHub</a>
         </span>
       {% if page.previous_page %}
         <span><a href="{{ page.previous_page.url|url }}" style="color: #fcfcfc">&laquo; {% trans %}Previous{% endtrans %}</a></span>


### PR DESCRIPTION
Usually offsite links open in a new tab.
If users want to navigate through the docs and also look at the Github page It is necessary to somehow copy the link or use a shortcut to open in other tab.