### PR TITLE
Fix code snippet compile errors

### DIFF
--- a/docs/advanced-js-interop.md
+++ b/docs/advanced-js-interop.md
@@ -127,6 +127,7 @@ type action =
 This will generate a couple of functions with the following types:
 
 <!--#prelude#
+(* type signature *)
 type action
 -->
 ```ocaml
@@ -175,6 +176,7 @@ to hide the JavaScript runtime representation. It will generate functions with
 the following types:
 
 <!--#prelude#
+(* type signature *)
 type action
 type abs_action
 -->
@@ -225,6 +227,7 @@ type action = [
 Akin to the variant example, the following two functions will be generated:
 
 <!--#prelude#
+(* type signature *)
 type action
 -->
 ```ocaml

--- a/docs/advanced-js-interop.md
+++ b/docs/advanced-js-interop.md
@@ -126,15 +126,18 @@ type action =
 
 This will generate a couple of functions with the following types:
 
+<!--#prelude#
+type action
+-->
 ```ocaml
 val actionToJs : action -> int
 
 val actionFromJs : int -> action option
 ```
 ```reasonml
-external actionToJs: action => int = ;
+let actionToJs: action => int;
 
-external actionFromJs: int => option(action) = ;
+let actionFromJs: int => option(action);
 ```
 
 `actionToJs` returns integers from values of `action` type. It will start with 0
@@ -171,15 +174,19 @@ This feature relies on [abstract types](./language-concepts.md#abstract-types)
 to hide the JavaScript runtime representation. It will generate functions with
 the following types:
 
+<!--#prelude#
+type action
+type abs_action
+-->
 ```ocaml
 val actionToJs : action -> abs_action
 
 val actionFromJs : abs_action -> action
 ```
 ```reasonml
-external actionToJs: action => abs_action = ;
+let actionToJs: action => abs_action;
 
-external actionFromJs: abs_action => action = ;
+let actionFromJs: abs_action => action;
 ```
 
 In the case of `actionFromJs`, the return value, unlike the previous case, is
@@ -217,15 +224,18 @@ type action = [
 
 Akin to the variant example, the following two functions will be generated:
 
+<!--#prelude#
+type action
+-->
 ```ocaml
 val actionToJs : action -> string
 
 val actionFromJs : string -> action option
 ```
 ```reasonml
-external actionToJs: action => string = ;
+let actionToJs: action => string;
 
-external actionFromJs: string => option(action) = ;
+let actionFromJs: string => option(action);
 ```
 
 The `jsConverter { newType }` payload can also be used with polymorphic
@@ -339,12 +349,12 @@ example, the OCaml signature would look like this after preprocessing:
 ```ocaml
 type person
 
-val person : name:string -> ?age:int -> unit -> person
+external person : name:string -> ?age:int -> unit -> person = "person"
 ```
 ```reasonml
 type person;
 
-external person: (~name: string, ~age: int=?, unit) => person = ;
+external person: (~name: string, ~age: int=?, unit) => person = "person";
 ```
 
 The `person` function can be used to create values of `person`. It is the only
@@ -359,7 +369,7 @@ type person = {
   name : string;
   age : int option; [@mel.optional]
 }
-[@@deriving jsDeriving]
+[@@deriving jsProperties]
 -->
 ```ocaml
 let alice = person ~name:"Alice" ~age:20 ()
@@ -533,14 +543,14 @@ type person = {
   name : string;
   mutable age : int;
 }
-[@@deriving getSet]
+[@@deriving jsProperties, getSet]
 
 let alice = person ~name:"Alice" ~age:20
 
 let () = ageSet alice 21
 ```
 ```reasonml
-[@deriving getSet]
+[@deriving (jsProperties, getSet)]
 type person = {
   name: string,
   mutable age: int,

--- a/docs/advanced-js-interop.md
+++ b/docs/advanced-js-interop.md
@@ -208,7 +208,11 @@ type action =
 ```
 ```reasonml
 [@deriving jsConverter]
-type action = [ | `Click | [@mel.as "submit"] `Submit | `Cancel];
+type action = [
+  | `Click
+  | [@mel.as "submit"] `Submit
+  | `Cancel
+];
 ```
 
 Akin to the variant example, the following two functions will be generated:

--- a/docs/bindings-cookbook.md
+++ b/docs/bindings-cookbook.md
@@ -266,7 +266,10 @@ literal directly:
 let person = [%mel.obj { id = 1; name = "Alice" }]
 ```
 ```reasonml
-let person = {"id": 1, "name": "Alice"};
+let person = {
+  "id": 1,
+  "name": "Alice",
+};
 ```
 
 See the [Using `Js.t`
@@ -285,7 +288,10 @@ type person = {
   id: int,
   name: string,
 };
-let person = {id: 1, name: "Alice"};
+let person = {
+  id: 1,
+  name: "Alice",
+};
 ```
 
 See the [Using OCaml
@@ -349,7 +355,10 @@ type person = {
   name: string,
 };
 
-let person = {id: 1, name: "Alice"};
+let person = {
+  id: 1,
+  name: "Alice",
+};
 let {id, name} = person;
 ```
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -160,6 +160,9 @@ application. In the root folder, create another `dune` file:
   And an <code>app.re</code> file:
 </div>
 
+<!--#prelude#
+module Lib = struct let name = "" end
+-->
 ```ocaml
 let () = Js.log Lib.name
 ```

--- a/docs/data-types-and-runtime-rep.md
+++ b/docs/data-types-and-runtime-rep.md
@@ -212,6 +212,10 @@ JavaScript arrays by Melange.
 
 For example, some code like this:
 
+<!--#prelude#
+let foo, bar = 1, 2
+module React = struct let useEffect2 _ _ = () end
+-->
 ```ocaml
 let () = React.useEffect2 (fun () -> None) (foo, bar)
 ```

--- a/docs/dune
+++ b/docs/dune
@@ -16,6 +16,102 @@
    communicate-with-javascript.md.processed)))
 
 (rule
+ (deps language-concepts.md)
+ (target language-concepts.md.processed)
+ (action
+  (with-stdout-to
+   %{target}
+   (with-stdin-from
+    %{deps}
+    (run %{bin:process_md})))))
+
+(rule
+ (alias re)
+ (action
+  (diff language-concepts.md language-concepts.md.processed)))
+
+(rule
+ (deps data-types-and-runtime-rep.md)
+ (target data-types-and-runtime-rep.md.processed)
+ (action
+  (with-stdout-to
+   %{target}
+   (with-stdin-from
+    %{deps}
+    (run %{bin:process_md})))))
+
+(rule
+ (alias re)
+ (action
+  (diff
+   data-types-and-runtime-rep.md
+   data-types-and-runtime-rep.md.processed)))
+
+(rule
+ (deps attributes-and-extension-nodes.md)
+ (target attributes-and-extension-nodes.md.processed)
+ (action
+  (with-stdout-to
+   %{target}
+   (with-stdin-from
+    %{deps}
+    (run %{bin:process_md})))))
+
+(rule
+ (alias re)
+ (action
+  (diff
+   attributes-and-extension-nodes.md
+   attributes-and-extension-nodes.md.processed)))
+
+(rule
+ (deps working-with-js-objects-and-values.md)
+ (target working-with-js-objects-and-values.md.processed)
+ (action
+  (with-stdout-to
+   %{target}
+   (with-stdin-from
+    %{deps}
+    (run %{bin:process_md})))))
+
+(rule
+ (alias re)
+ (action
+  (diff
+   working-with-js-objects-and-values.md
+   working-with-js-objects-and-values.md.processed)))
+
+(rule
+ (deps advanced-js-interop.md)
+ (target advanced-js-interop.md.processed)
+ (action
+  (with-stdout-to
+   %{target}
+   (with-stdin-from
+    %{deps}
+    (run %{bin:process_md})))))
+
+(rule
+ (alias re)
+ (action
+  (diff advanced-js-interop.md advanced-js-interop.md.processed)))
+
+(rule
+ (deps bindings-cookbook.md)
+ (target bindings-cookbook.md.processed)
+ (action
+  (with-stdout-to
+   %{target}
+   (with-stdin-from
+    %{deps}
+    (run %{bin:process_md})))))
+
+(rule
+ (alias re)
+ (action
+  (diff bindings-cookbook.md bindings-cookbook.md.processed)))
+
+(rule
  (deps build-system.md)
  (target build-system.md.processed)
  (action

--- a/docs/language-concepts.md
+++ b/docs/language-concepts.md
@@ -300,6 +300,9 @@ let square = x => x * x;
 
 We are using it like:
 
+<!--#prelude#
+let square x = x * x
+-->
 ```ocaml
 let ten = succ (square 3)
 ```
@@ -311,6 +314,9 @@ The pipe operator allows to write the computation for `ten` in left-to-right
 order, as [it has left
 associativity](https://v2.ocaml.org/manual/expr.html#ss:precedence-and-associativity):
 
+<!--#prelude#
+let square x = x * x
+-->
 ```ocaml
 let ten = 3 |> square |> succ
 ```
@@ -322,6 +328,9 @@ When working with functions that can take multiple arguments, the pipe operator
 works best when the functions take the data we are processing as the last
 argument. For example:
 
+<!--#prelude#
+let square x = x * x
+-->
 ```ocaml
 let sum = List.fold_left ( + ) 0
 
@@ -349,6 +358,9 @@ language.
 However, there are some limitations when using data-last when it comes to error
 handling. In the given example, if we mistakenly used the wrong function:
 
+<!--#prelude#
+let sum = List.fold_left ( + ) 0
+-->
 ```ocaml
 let sum_sq =
   [ 1; 2; 3 ]
@@ -402,6 +414,10 @@ with the pipe first operator.
 For example, we can rewrite the example above using `Belt.List.map` and the pipe
 first operator:
 
+<!--#prelude#
+let sum = List.fold_left ( + ) 0
+let square x = x * x
+-->
 ```ocaml
 let sum_sq =
   [ 1; 2; 3 ]
@@ -415,6 +431,10 @@ let sum_sq = [1, 2, 3]->(Belt.List.map(square))->sum;
 We can see the difference on the error we get if the wrong function is passed to
 `Belt.List.map`:
 
+<!--#prelude#
+let sum = List.fold_left ( + ) 0
+let square x = x * x
+-->
 ```ocaml
 let sum_sq =
   [ 1; 2; 3 ]

--- a/docs/language-concepts.md
+++ b/docs/language-concepts.md
@@ -359,6 +359,7 @@ However, there are some limitations when using data-last when it comes to error
 handling. In the given example, if we mistakenly used the wrong function:
 
 <!--#prelude#
+(* not expected to type check *)
 let sum = List.fold_left ( + ) 0
 -->
 ```ocaml
@@ -432,6 +433,7 @@ We can see the difference on the error we get if the wrong function is passed to
 `Belt.List.map`:
 
 <!--#prelude#
+(* not expected to type check *)
 let sum = List.fold_left ( + ) 0
 let square x = x * x
 -->

--- a/docs/working-with-js-objects-and-values.md
+++ b/docs/working-with-js-objects-and-values.md
@@ -231,9 +231,9 @@ external route :
   _type:string ->
   path:string ->
   action:(string list -> unit) ->
-  ?options:< .. > ->
+  ?options:'a ->
   unit ->
-  _ = ""
+  'b = ""
   [@@mel.obj]
 ```
 ```reasonml
@@ -243,10 +243,10 @@ external route:
     ~_type: string,
     ~path: string,
     ~action: list(string) => unit,
-    ~options: {..}=?,
+    ~options: 'a=?,
     unit
   ) =>
-  _;
+  'b;
 ```
 
 Note that the empty string at the end of the function is used to make it
@@ -271,6 +271,16 @@ the `mel.as` attribute can be used to rename fields.
 
 If we call the function like this:
 
+<!--#prelude#
+external route :
+  _type:string ->
+  path:string ->
+  action:(string list -> unit) ->
+  ?options:'a ->
+  unit ->
+  'b = ""
+  [@@mel.obj]
+-->
 ```ocaml
 let homeRoute = route ~_type:"GET" ~path:"/" ~action:(fun _ -> Js.log "Home") ()
 ```
@@ -523,7 +533,7 @@ can do:
 
 ```ocaml
 type param
-external executeCommands : string -> param array -> unit = ""
+external executeCommands : string -> param array -> unit = "executeCommands"
   [@@mel.scope "commands"] [@@mel.module "vscode"] [@@mel.variadic]
 
 let f a b c = executeCommands "hi" [| a; b; c |]
@@ -531,7 +541,7 @@ let f a b c = executeCommands "hi" [| a; b; c |]
 ```reasonml
 type param;
 [@mel.scope "commands"] [@mel.module "vscode"] [@mel.variadic]
-external executeCommands: (string, array(param)) => unit;
+external executeCommands: (string, array(param)) => unit = "executeCommands";
 
 let f = (a, b, c) => executeCommands("hi", [|a, b, c|]);
 ```
@@ -1035,7 +1045,7 @@ If the values are strings, we can use the `mel.string` attribute:
 
 ```ocaml
 external read_file_sync :
-  name:string -> ([ `utf8 | `ascii ][@mel.string]) -> string = "readFileSync"
+  name:string -> ([ `utf8 | `ascii ]) -> string = "readFileSync"
   [@@mel.module "fs"]
 
 let _ = read_file_sync ~name:"xx.txt" `ascii
@@ -1045,7 +1055,7 @@ let _ = read_file_sync ~name:"xx.txt" `ascii
 external read_file_sync:
   (
     ~name: string,
-    [@mel.string] [
+    [
       | `utf8
       | `ascii
     ]
@@ -1175,7 +1185,7 @@ external on :
   [@@mel.send]
 
 let register rl =
-  rl |. on (`close (fun event -> ())) |. on (`line (fun line -> Js.log line))
+  rl |. on (`close (fun _event -> ())) |. on (`line (fun line -> Js.log line))
 ```
 ```reasonml
 type readline;
@@ -1193,7 +1203,7 @@ external on:
   "on";
 
 let register = rl =>
-  rl->(on(`close(event => ())))->(on(`line(line => Js.log(line))));
+  rl->(on(`close(_event => ())))->(on(`line(line => Js.log(line))));
 ```
 
 This generates:
@@ -1367,6 +1377,9 @@ except the former’s arity is guaranteed to be N while the latter is unknown.
 
 If we try now to call `map` using `add`:
 
+<!--#prelude#
+external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@u]) -> 'c array = "map"
+-->
 ```ocaml
 let add x y = x + y
 let _ = map [||] [||] add
@@ -1415,6 +1428,9 @@ external map:
 
 Now if we try to call `map` with a regular `add` function:
 
+<!--#prelude#
+external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@mel.uncurry]) -> 'c array = "map"
+-->
 ```ocaml
 let add x y = x + y
 let _ = map [||] [||] add

--- a/docs/working-with-js-objects-and-values.md
+++ b/docs/working-with-js-objects-and-values.md
@@ -110,7 +110,10 @@ type t = {
   bar: string,
 };
 
-let value = {foo: 7, bar: "baz"};
+let value = {
+  foo: 7,
+  bar: "baz",
+};
 ```
 
 And its JavaScript generated code:
@@ -142,7 +145,10 @@ let john = [%mel.obj { name = "john"; age = 99 }]
 let t = john##name
 ```
 ```reasonml
-let john = {"name": "john", "age": 99};
+let john = {
+  "name": "john",
+  "age": 99,
+};
 let t = john##name;
 ```
 
@@ -175,8 +181,16 @@ let two = name_extended [%mel.obj { name = "jane"; address = "1 infinite loop" }
 ```reasonml
 let name_extended = obj => obj##name ++ " wayne";
 
-let one = name_extended({"name": "john", "age": 99});
-let two = name_extended({"name": "jane", "address": "1 infinite loop"});
+let one =
+  name_extended({
+    "name": "john",
+    "age": 99,
+  });
+let two =
+  name_extended({
+    "name": "jane",
+    "address": "1 infinite loop",
+  });
 ```
 
 To read more about objects and polymorphism we recommend checking the [OCaml
@@ -976,7 +990,14 @@ let _ = padLeft "Hello World" (`Str "Message from Melange: ")
 ```
 ```reasonml
 external padLeft:
-  (string, [@mel.unwrap] [ | `Str(string) | `Int(int)]) => string =
+  (
+    string,
+    [@mel.unwrap] [
+      | `Str(string)
+      | `Int(int)
+    ]
+  ) =>
+  string =
   "padLeft";
 
 let _ = padLeft("Hello World", `Int(4));
@@ -1022,7 +1043,14 @@ let _ = read_file_sync ~name:"xx.txt" `ascii
 ```reasonml
 [@mel.module "fs"]
 external read_file_sync:
-  (~name: string, [@mel.string] [ | `utf8 | `ascii]) => string =
+  (
+    ~name: string,
+    [@mel.string] [
+      | `utf8
+      | `ascii
+    ]
+  ) =>
+  string =
   "readFileSync";
 
 let _ = read_file_sync(~name="xx.txt", `ascii);
@@ -1107,7 +1135,15 @@ let value = test_int_type `on_open
 ```
 ```reasonml
 external test_int_type:
-  ([@mel.int] [ | `on_closed | [@mel.as 20] `on_open | `in_bin]) => int =
+  (
+  [@mel.int]
+  [
+    | `on_closed
+    | [@mel.as 20] `on_open
+    | `in_bin
+  ]
+  ) =>
+  int =
   "testIntType";
 
 let value = test_int_type(`on_open);
@@ -1148,7 +1184,10 @@ type readline;
 external on:
   (
     readline,
-    [@mel.string] [ | `close(unit => unit) | `line(string => unit)]
+    [@mel.string] [
+      | `close(unit => unit)
+      | `line(string => unit)
+    ]
   ) =>
   readline =
   "on";

--- a/docs/working-with-js-objects-and-values.md
+++ b/docs/working-with-js-objects-and-values.md
@@ -1378,6 +1378,7 @@ except the former’s arity is guaranteed to be N while the latter is unknown.
 If we try now to call `map` using `add`:
 
 <!--#prelude#
+(* not expected to type check *)
 external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@u]) -> 'c array = "map"
 -->
 ```ocaml

--- a/scripts/advanced-js-interop.t
+++ b/scripts/advanced-js-interop.t
@@ -160,6 +160,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > 
+  > (* type signature *)
   > type action
   > 
   > val actionToJs : action -> string
@@ -168,8 +169,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 4, characters 0-33:
-  4 | val actionToJs : action -> string
+  File "input.ml", line 5, characters 0-33:
+  5 | val actionToJs : action -> string
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Value declarations are only allowed in signatures
   [1]
@@ -187,6 +188,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > 
+  > (* type signature *)
   > type action
   > type abs_action
   > 
@@ -196,8 +198,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 0-37:
-  5 | val actionToJs : action -> abs_action
+  File "input.ml", line 6, characters 0-37:
+  6 | val actionToJs : action -> abs_action
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Value declarations are only allowed in signatures
   [1]
@@ -214,6 +216,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > 
+  > (* type signature *)
   > type action
   > 
   > val actionToJs : action -> int
@@ -222,8 +225,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 4, characters 0-30:
-  4 | val actionToJs : action -> int
+  File "input.ml", line 5, characters 0-30:
+  5 | val actionToJs : action -> int
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Value declarations are only allowed in signatures
   [1]

--- a/scripts/advanced-js-interop.t
+++ b/scripts/advanced-js-interop.t
@@ -41,7 +41,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   name : string;
   >   mutable age : int;
   > }
-  > [@@deriving getSet]
+  > [@@deriving jsProperties, getSet]
   > 
   > let alice = person ~name:"Alice" ~age:20
   > 
@@ -49,11 +49,6 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 7, characters 12-18:
-  7 | let alice = person ~name:"Alice" ~age:20
-                  ^^^^^^
-  Error: Unbound value person
-  [1]
 
   $ cat > input.ml <<\EOF
   > type person = {
@@ -111,39 +106,21 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   name : string;
   >   age : int option; [@mel.optional]
   > }
-  > [@@deriving jsDeriving]
+  > [@@deriving jsProperties]
   > 
   > let alice = person ~name:"Alice" ~age:20 ()
   > let bob = person ~name:"Bob" ()
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 4, characters 22-34:
-  4 |   age : int option; [@mel.optional]
-                            ^^^^^^^^^^^^
-  Alert unused: Unused attribute [@mel.optional]
-  This means such annotation is not annotated properly.
-  For example, some annotations are only meaningful in externals
-  
-  File "input.ml", line 6, characters 12-22:
-  6 | [@@deriving jsDeriving]
-                  ^^^^^^^^^^
-  Error: Ppxlib.Deriving: 'jsDeriving' is not a supported type deriving
-         generator
-  [1]
 
   $ cat > input.ml <<\EOF
   > type person
   > 
-  > val person : name:string -> ?age:int -> unit -> person
+  > external person : name:string -> ?age:int -> unit -> person = "person"
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 3, characters 0-54:
-  3 | val person : name:string -> ?age:int -> unit -> person
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Value declarations are only allowed in signatures
-  [1]
 
   $ cat > input.ml <<\EOF
   > type person = {
@@ -182,17 +159,19 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > type action
+  > 
   > val actionToJs : action -> string
   > 
   > val actionFromJs : string -> action option
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 17-23:
-  1 | val actionToJs : action -> string
-                       ^^^^^^
-  Error: Unbound type constructor action
-  Hint: Did you mean option?
+  File "input.ml", line 4, characters 0-33:
+  4 | val actionToJs : action -> string
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Value declarations are only allowed in signatures
   [1]
 
   $ cat > input.ml <<\EOF
@@ -207,17 +186,20 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > type action
+  > type abs_action
+  > 
   > val actionToJs : action -> abs_action
   > 
   > val actionFromJs : abs_action -> action
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 17-23:
-  1 | val actionToJs : action -> abs_action
-                       ^^^^^^
-  Error: Unbound type constructor action
-  Hint: Did you mean option?
+  File "input.ml", line 5, characters 0-37:
+  5 | val actionToJs : action -> abs_action
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Value declarations are only allowed in signatures
   [1]
 
   $ cat > input.ml <<\EOF
@@ -231,17 +213,19 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > type action
+  > 
   > val actionToJs : action -> int
   > 
   > val actionFromJs : int -> action option
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 17-23:
-  1 | val actionToJs : action -> int
-                       ^^^^^^
-  Error: Unbound type constructor action
-  Hint: Did you mean option?
+  File "input.ml", line 4, characters 0-30:
+  4 | val actionToJs : action -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Value declarations are only allowed in signatures
   [1]
 
   $ cat > input.ml <<\EOF

--- a/scripts/build-system.t
+++ b/scripts/build-system.t
@@ -23,15 +23,13 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > module Lib = struct let name = "" end
+  > 
   > let () = Js.log Lib.name
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 16-24:
-  1 | let () = Js.log Lib.name
-                      ^^^^^^^^
-  Error: Unbound module Lib
-  [1]
 
   $ cat > input.ml <<\EOF
   > let name = "Jane"

--- a/scripts/data-types-and-runtime-rep.t
+++ b/scripts/data-types-and-runtime-rep.t
@@ -21,15 +21,14 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > let foo, bar = 1, 2
+  > module React = struct let useEffect2 _ _ = () end
+  > 
   > let () = React.useEffect2 (fun () -> None) (foo, bar)
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 9-25:
-  1 | let () = React.useEffect2 (fun () -> None) (foo, bar)
-               ^^^^^^^^^^^^^^^^
-  Error: Unbound module React
-  [1]
 
   $ cat > input.ml <<\EOF
   > let world = {j|世界|j}

--- a/scripts/dune
+++ b/scripts/dune
@@ -20,6 +20,8 @@
  (applies_to add_canonical)
  (deps %{bin:add_canonical}))
 
+; Extract code blocks from markdown files
+
 (rule
  (deps ../docs/communicate-with-javascript.md)
  (target communicate-with-javascript.md.processed)

--- a/scripts/dune
+++ b/scripts/dune
@@ -20,7 +20,7 @@
  (applies_to add_canonical)
  (deps %{bin:add_canonical}))
 
-; Extract code blocks from markdown files
+;; Extract code blocks from markdown files
 
 (rule
  (deps ../docs/communicate-with-javascript.md)
@@ -147,3 +147,4 @@
  (alias extract-code-blocks)
  (action
   (diff build-system.t build-system.md.processed)))
+

--- a/scripts/language-concepts.t
+++ b/scripts/language-concepts.t
@@ -16,6 +16,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > 
+  > (* not expected to type check *)
   > let sum = List.fold_left ( + ) 0
   > let square x = x * x
   > 
@@ -26,8 +27,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 7, characters 19-29:
-  7 |   |. Belt.List.map String.cat
+  File "input.ml", line 8, characters 19-29:
+  8 |   |. Belt.List.map String.cat
                          ^^^^^^^^^^
   Error: This expression has type string -> string -> string
          but an expression was expected of type int -> 'a
@@ -49,6 +50,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > 
+  > (* not expected to type check *)
   > let sum = List.fold_left ( + ) 0
   > 
   > let sum_sq =
@@ -58,8 +60,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 4-5:
-  5 |   [ 1; 2; 3 ]
+  File "input.ml", line 6, characters 4-5:
+  6 |   [ 1; 2; 3 ]
           ^
   Error: This expression has type int but an expression was expected of type
            string

--- a/scripts/language-concepts.t
+++ b/scripts/language-concepts.t
@@ -15,6 +15,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ cat > input.ml <<\EOF
+  > 
+  > let sum = List.fold_left ( + ) 0
+  > let square x = x * x
+  > 
   > let sum_sq =
   >   [ 1; 2; 3 ]
   >   |. Belt.List.map String.cat
@@ -22,13 +26,19 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 4, characters 5-8:
-  4 |   |. sum
-           ^^^
-  Error: Unbound value sum
+  File "input.ml", line 7, characters 19-29:
+  7 |   |. Belt.List.map String.cat
+                         ^^^^^^^^^^
+  Error: This expression has type string -> string -> string
+         but an expression was expected of type int -> 'a
+         Type string is not compatible with type int
   [1]
 
   $ cat > input.ml <<\EOF
+  > 
+  > let sum = List.fold_left ( + ) 0
+  > let square x = x * x
+  > 
   > let sum_sq =
   >   [ 1; 2; 3 ]
   >   |. Belt.List.map square
@@ -36,13 +46,11 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 4, characters 5-8:
-  4 |   |. sum
-           ^^^
-  Error: Unbound value sum
-  [1]
 
   $ cat > input.ml <<\EOF
+  > 
+  > let sum = List.fold_left ( + ) 0
+  > 
   > let sum_sq =
   >   [ 1; 2; 3 ]
   >   |> List.map String.cat
@@ -50,13 +58,17 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 4, characters 5-8:
-  4 |   |> sum
-           ^^^
-  Error: Unbound value sum
+  File "input.ml", line 5, characters 4-5:
+  5 |   [ 1; 2; 3 ]
+          ^
+  Error: This expression has type int but an expression was expected of type
+           string
   [1]
 
   $ cat > input.ml <<\EOF
+  > 
+  > let square x = x * x
+  > 
   > let sum = List.fold_left ( + ) 0
   > 
   > let sum_sq =
@@ -66,33 +78,24 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 14-20:
-  5 |   |> List.map square (* [1; 4; 9] *)
-                    ^^^^^^
-  Error: Unbound value square
-  [1]
 
   $ cat > input.ml <<\EOF
+  > 
+  > let square x = x * x
+  > 
   > let ten = 3 |> square |> succ
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 15-21:
-  1 | let ten = 3 |> square |> succ
-                     ^^^^^^
-  Error: Unbound value square
-  [1]
 
   $ cat > input.ml <<\EOF
+  > 
+  > let square x = x * x
+  > 
   > let ten = succ (square 3)
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 16-22:
-  1 | let ten = succ (square 3)
-                      ^^^^^^
-  Error: Unbound value square
-  [1]
 
   $ cat > input.ml <<\EOF
   > let square x = x * x

--- a/scripts/process_md.ml
+++ b/scripts/process_md.ml
@@ -9,17 +9,15 @@ let print_re = print_with Reason_toolchain.RE.print_implementation_with_comments
 
 (* Remove the first and second to last lines of a string and dedent every line *)
 let designature s =
-  match String.split_on_char '\n' s with
-  | [] | [ _ ] | [ _; _ ] -> ""
-  | _ :: rest -> (
-      match List.rev rest with
-      | [] | [ _ ] -> ""
-      | last :: _ :: rest ->
-          let dedent s =
-            let n = String.length s in
-            if n <= 2 then "" else String.sub s 2 (n - 2)
-          in
-          last :: rest |> List.map dedent |> List.rev |> String.concat "\n")
+  let dedent s =
+    let n = String.length s in
+    if n <= 2 then "" else String.sub s 2 (n - 2)
+  in
+  let lines = String.split_on_char '\n' s in
+  let len = List.length lines in
+  lines
+  |> List.filteri (fun i _ -> i <> 0 && i <> len - 2)
+  |> List.map dedent |> String.concat "\n"
 
 let to_re str =
   let is_type_signature, str =

--- a/scripts/process_md.ml
+++ b/scripts/process_md.ml
@@ -7,14 +7,35 @@ let print_with f structureAndComments =
 let parse_ml = parse_with Reason_toolchain.ML.implementation_with_comments
 let print_re = print_with Reason_toolchain.RE.print_implementation_with_comments
 
+(* Remove the first and second to last lines of a string and dedent every line *)
+let designature s =
+  match String.split_on_char '\n' s with
+  | [] | [ _ ] | [ _; _ ] -> ""
+  | _ :: rest -> (
+      match List.rev rest with
+      | [] | [ _ ] -> ""
+      | last :: _ :: rest ->
+          let dedent s =
+            let n = String.length s in
+            if n <= 2 then "" else String.sub s 2 (n - 2)
+          in
+          last :: rest |> List.map dedent |> List.rev |> String.concat "\n")
+
 let to_re str =
+  let is_type_signature, str =
+    (* assume that any snippet starting with "val" is a partial type signature *)
+    if String.starts_with str ~prefix:"val " then
+      (true, "module type _FAKE_  = sig " ^ str ^ " end")
+    else (false, str)
+  in
   try
     let parsed_ast = parse_ml str in
-    print_re parsed_ast
+    let output = print_re parsed_ast in
+    if is_type_signature then designature output else output
   with _ ->
     failwith ("Failed to convert OCaml snippet to Reason syntax: " ^ str)
 
-let remove_last_endline s =
+let remove_last_newline s =
   let n = String.length s in
   if n > 0 && s.[n - 1] = '\n' then String.sub s 0 (n - 1) else s
 
@@ -31,7 +52,7 @@ let insert_reason_blocks doc =
             let ocaml_code_str =
               String.concat "\n" (List.map Block_line.to_string ocaml_code)
             in
-            let reason_code_str = remove_last_endline (to_re ocaml_code_str) in
+            let reason_code_str = remove_last_newline (to_re ocaml_code_str) in
             let reason_code = Block_line.list_of_string reason_code_str in
             let cb =
               Block.Code_block.make ~layout ~info_string:reason_info reason_code
@@ -50,12 +71,10 @@ let cmark_to_commonmark : strict:bool -> string -> string =
   let processed = insert_reason_blocks doc in
   Cmarkit_commonmark.of_doc processed
 
-let maybe_read_line () = try Some (read_line ()) with End_of_file -> None
-
 let rec loop acc =
-  match maybe_read_line () with
-  | Some line -> loop (line :: acc)
-  | None -> List.rev acc
+  match read_line () with
+  | exception End_of_file -> List.rev acc
+  | line -> loop (line :: acc)
 
 let input = String.concat "\n" (loop [])
 let () = print_endline (cmark_to_commonmark ~strict:false input)

--- a/scripts/working-with-js-objects-and-values.t
+++ b/scripts/working-with-js-objects-and-values.t
@@ -45,17 +45,14 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@mel.uncurry]) -> 'c array = "map"
+  > 
   > let add x y = x + y
   > let _ = map [||] [||] add
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 2, characters 8-11:
-  2 | let _ = map [||] [||] add
-              ^^^
-  Error: Unbound value map
-  Hint: Did you mean max?
-  [1]
 
   $ cat > input.ml <<\EOF
   > external map :
@@ -71,16 +68,19 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@u]) -> 'c array = "map"
+  > 
   > let add x y = x + y
   > let _ = map [||] [||] add
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 2, characters 8-11:
-  2 | let _ = map [||] [||] add
-              ^^^
-  Error: Unbound value map
-  Hint: Did you mean max?
+  File "input.ml", line 5, characters 22-25:
+  5 | let _ = map [||] [||] add
+                            ^^^
+  Error: This expression has type int -> int -> int
+         but an expression was expected of type ('a -> 'b -> 'c [@u])
   [1]
 
   $ cat > input.ml <<\EOF
@@ -129,15 +129,10 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   >   [@@mel.send]
   > 
   > let register rl =
-  >   rl |. on (`close (fun event -> ())) |. on (`line (fun line -> Js.log line))
+  >   rl |. on (`close (fun _event -> ())) |. on (`line (fun line -> Js.log line))
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 10, characters 24-29:
-  10 |   rl |. on (`close (fun event -> ())) |. on (`line (fun line -> Js.log line))
-                               ^^^^^
-  Error (warning 27 [unused-var-strict]): unused variable event.
-  [1]
 
   $ cat > input.ml <<\EOF
   > external test_int_type :
@@ -176,17 +171,13 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > external read_file_sync :
-  >   name:string -> ([ `utf8 | `ascii ][@mel.string]) -> string = "readFileSync"
+  >   name:string -> ([ `utf8 | `ascii ]) -> string = "readFileSync"
   >   [@@mel.module "fs"]
   > 
   > let _ = read_file_sync ~name:"xx.txt" `ascii
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 2, characters 18-36:
-  2 |   name:string -> ([ `utf8 | `ascii ][@mel.string]) -> string = "readFileSync"
-                        ^^^^^^^^^^^^^^^^^^
-  Alert redundant: [@mel.string] is redundant here, you can safely remove it
 
   $ cat > input.ml <<\EOF
   > external padLeft:
@@ -338,17 +329,13 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > type param
-  > external executeCommands : string -> param array -> unit = ""
+  > external executeCommands : string -> param array -> unit = "executeCommands"
   >   [@@mel.scope "commands"] [@@mel.module "vscode"] [@@mel.variadic]
   > 
   > let f a b c = executeCommands "hi" [| a; b; c |]
   > EOF
 
   $ dune build @melange
-  File "input.ml", lines 2-3, characters 0-67:
-  2 | external executeCommands : string -> param array -> unit = ""
-  3 |   [@@mel.scope "commands"] [@@mel.module "vscode"] [@@mel.variadic]
-  Alert fragile: executeCommands : the external name is inferred from val name is unsafe from refactoring when changing value name
 
   $ cat > input.ml <<\EOF
   > external dirname : string -> string = "dirname" [@@mel.module "path"]
@@ -425,24 +412,29 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
+  > 
+  > external route :
+  >   _type:string ->
+  >   path:string ->
+  >   action:(string list -> unit) ->
+  >   ?options:'a ->
+  >   unit ->
+  >   'b = ""
+  >   [@@mel.obj]
+  > 
   > let homeRoute = route ~_type:"GET" ~path:"/" ~action:(fun _ -> Js.log "Home") ()
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 1, characters 16-21:
-  1 | let homeRoute = route ~_type:"GET" ~path:"/" ~action:(fun _ -> Js.log "Home") ()
-                      ^^^^^
-  Error: Unbound value route
-  [1]
 
   $ cat > input.ml <<\EOF
   > external route :
   >   _type:string ->
   >   path:string ->
   >   action:(string list -> unit) ->
-  >   ?options:< .. > ->
+  >   ?options:'a ->
   >   unit ->
-  >   _ = ""
+  >   'b = ""
   >   [@@mel.obj]
   > EOF
 

--- a/scripts/working-with-js-objects-and-values.t
+++ b/scripts/working-with-js-objects-and-values.t
@@ -414,29 +414,36 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > 
-  > external route :
+  > external makePlace :
+  >   name:string ->
   >   _type:string ->
-  >   path:string ->
-  >   action:(string list -> unit) ->
-  >   ?options:'a ->
+  >   greeting:(unit -> unit) ->
+  >   ?attractions:string array ->
   >   unit ->
-  >   'b = ""
-  >   [@@mel.obj]
+  >   _ = ""
+  > [@@mel.obj]
   > 
-  > let homeRoute = route ~_type:"GET" ~path:"/" ~action:(fun _ -> Js.log "Home") ()
+  > let place1 =
+  >   makePlace ~name:"Boring" ~_type:"city" ~greeting:(fun () -> Js.log "Howdy") ()
+  > 
+  > let place2 =
+  >   makePlace ~name:"Singapore" ~_type:"city state"
+  >     ~greeting:(fun () -> Js.log "Hello lah")
+  >     ~attractions:[| "Buddha Tooth"; "Baba House"; "Night Safari" |]
+  >     ()
   > EOF
 
   $ dune build @melange
 
   $ cat > input.ml <<\EOF
-  > external route :
+  > external makePlace :
+  >   name:string ->
   >   _type:string ->
-  >   path:string ->
-  >   action:(string list -> unit) ->
-  >   ?options:'a ->
+  >   greeting:(unit -> unit) ->
+  >   ?attractions:string array ->
   >   unit ->
-  >   'b = ""
-  >   [@@mel.obj]
+  >   _ = ""
+  > [@@mel.obj]
   > EOF
 
   $ dune build @melange

--- a/scripts/working-with-js-objects-and-values.t
+++ b/scripts/working-with-js-objects-and-values.t
@@ -69,6 +69,7 @@ file. To update the tests, run `dune build @extract-code-blocks`.
 
   $ cat > input.ml <<\EOF
   > 
+  > (* not expected to type check *)
   > external map : 'a array -> 'b array -> (('a -> 'b -> 'c)[@u]) -> 'c array = "map"
   > 
   > let add x y = x + y
@@ -76,8 +77,8 @@ file. To update the tests, run `dune build @extract-code-blocks`.
   > EOF
 
   $ dune build @melange
-  File "input.ml", line 5, characters 22-25:
-  5 | let _ = map [||] [||] add
+  File "input.ml", line 6, characters 22-25:
+  6 | let _ = map [||] [||] add
                             ^^^
   Error: This expression has type int -> int -> int
          but an expression was expected of type ('a -> 'b -> 'c [@u])


### PR DESCRIPTION
Also fix:
- [x] Formatting of reason snippets (because 3.14 formats records a bit differently)
- [x] Properly convert snippets that contain type signatures 

`process_md.ml` has been changed so that when it detects a snippet that begins with "val ", it assumes that it contains type signatures and wraps it with `module type _FAKE_  = sig ` and ` end`. After it converts to reason code, the extra lines are removed.