### PR TITLE
point canonical docs to v7.0.1

### DIFF
--- a/scripts/add_canonical.ml
+++ b/scripts/add_canonical.ml
@@ -42,7 +42,7 @@ let replace_in_file ~orig_path file_path search_str =
     in
     let canonical_link =
       Printf.sprintf
-        "<link rel=\"canonical\" href=\"https://melange.re/v6.0.1/api/%s\" \
+        "<link rel=\"canonical\" href=\"https://melange.re/v7.0.1/api/%s\" \
          /></head>"
         (String.escaped relative_file_path)
     in

--- a/scripts/add_canonical.t
+++ b/scripts/add_canonical.t
@@ -7,7 +7,7 @@ Test add_canonical exe
   $ add_canonical .
 
   $ cat foo.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/foo.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/foo.html" /></head>
 
 
   $ mkdir -p melange/Js/Global
@@ -98,46 +98,46 @@ Test add_canonical exe
   $ add_canonical .
 
   $ cat ./melange/Js/Global/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Js/Global/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Js/Global/index.html" /></head>
 
   $ cat ./melange/Node/Foo/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Node/Foo/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Node/Foo/index.html" /></head>
 
   $ cat ./melange/Dom/Storage2/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Dom/Storage2/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Dom/Storage2/index.html" /></head>
 
   $ cat ./melange/Belt/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Belt/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Belt/index.html" /></head>
 
   $ cat ./melange/Belt/List/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Belt/List/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Belt/List/index.html" /></head>
 
   $ cat ./melange/Stdlib/Int/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Stdlib/Int/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Stdlib/Int/index.html" /></head>
 
   $ cat ./melange/Js/Typed_array/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Js/Typed_array/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Js/Typed_array/index.html" /></head>
 
   $ cat ./melange/Js/TypedArray2/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Js/TypedArray2/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Js/TypedArray2/index.html" /></head>
 
   $ cat ./melange/Js/WeakSet/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Js/WeakSet/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Js/WeakSet/index.html" /></head>
 
   $ cat ./melange/Js/Fn/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Js/Fn/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Js/Fn/index.html" /></head>
 
   $ cat ./melange/Belt/Set/String/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Belt/Set/String/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Belt/Set/String/index.html" /></head>
 
   $ cat ./melange/Belt/Map/Dict/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Belt/Map/Dict/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Belt/Map/Dict/index.html" /></head>
 
   $ cat ./melange/Belt/SortArray/Int/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Belt/SortArray/Int/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Belt/SortArray/Int/index.html" /></head>
 
   $ cat ./melange/Melange_ppx/Ast_literal/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Melange_ppx/Ast_literal/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Melange_ppx/Ast_literal/index.html" /></head>
 
   $ cat ./melange/Melange_ppx/External/index.html
-  <head><link rel="canonical" href="https://melange.re/v6.0.1/api/melange/Melange_ppx/External/index.html" /></head>
+  <head><link rel="canonical" href="https://melange.re/v7.0.1/api/melange/Melange_ppx/External/index.html" /></head>


### PR DESCRIPTION
Points unstable API canonical URLs to the v7.0.1 docs prepared in #237.