### PR TITLE
make v7.0.1 the default docs version

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8">
   <title>Redirecting</title>
   <noscript>
-    <meta http-equiv="refresh" content="1; url=v6.0.1/" />
+    <meta http-equiv="refresh" content="1; url=v7.0.1/" />
   </noscript>
   <script>
-    window.location.replace("v6.0.1/" + window.location.hash);
+    window.location.replace("v7.0.1/" + window.location.hash);
   </script>
 </head>
 <body>
-  Redirecting to <a href="v6.0.1/">v6.0.1/</a>...
+  Redirecting to <a href="v7.0.1/">v7.0.1/</a>...
 </body>
 </html>

--- a/robots.txt
+++ b/robots.txt
@@ -19,3 +19,5 @@ Sitemap: https://melange.re/v4.0.0/sitemap.xml
 Sitemap: https://melange.re/v5.0.0/sitemap.xml
 
 Sitemap: https://melange.re/v6.0.1/sitemap.xml
+
+Sitemap: https://melange.re/v7.0.1/sitemap.xml


### PR DESCRIPTION
Updates the default redirect and sitemap list for the v7.0.1 docs published from #237.