### PR TITLE
backport OCaml 5.5 docs to v7.0.1

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -65,7 +65,7 @@ First of all, create an opam switch, as shown in the [package management
 section](package-management.md):
 
 ```bash
-opam switch create . 5.3.0 --deps-only
+opam switch create . 5.5.0 --deps-only
 ```
 
 Install the latest versions of Dune and Melange in the switch:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ For Visual Studio Code, install the [OCaml Platform Visual Studio Code
 extension](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform)
 from the Visual Studio Marketplace. When you load an OCaml source file for the
 first time, you may be prompted to select the toolchain to use. Select the
-version of OCaml you are using from the list, such as 5.3.0. Refer to [Supported
+version of OCaml you are using from the list, such as 5.5.0. Refer to [Supported
 Syntaxes](/syntaxes) to learn how to set up format-on-save. Further
 instructions for configuration can be found in the [extension
 repository](https://github.com/ocamllabs/vscode-ocaml-platform#setting-up-the-extension-for-your-project).

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -60,7 +60,7 @@ switch](https://opam.ocaml.org/blog/opam-local-switches/) to start working on
 our library:
 
 ```bash
-opam switch create . 5.3.0 -y --deps-only
+opam switch create . 5.5.0 -y --deps-only
 ```
 
 Once this step is done, we can call `dune` from the library folder, but first we
@@ -450,7 +450,7 @@ opam update
 Now, update the version of the OCaml compiler in the local switch to 5.1:
 
 ```bash
-opam install --update-invariant ocaml-base-compiler.5.3.0
+opam install --update-invariant ocaml-base-compiler.5.1.1
 ```
 
 Finally, we can upgrade all packages to get Melange v2 and the latest version of
@@ -467,7 +467,7 @@ subcommand:
 opam list --installed melange
 # Packages matching: name-match(melange) & installed
 # Name  # Installed    # Synopsis
-melange 7.0.1-55       Toolchain to produce JS from Reason/OCaml
+melange 2.2.0          Toolchain to produce JS from Reason/OCaml
 ```
 
 Before building, we have to update some parts of the configuration to make it

--- a/docs/melange-for-x-developers.md
+++ b/docs/melange-for-x-developers.md
@@ -581,8 +581,9 @@ architectures are not included in the pre-built binaries.
 ### OCaml compiler version
 
 ReScript is compatible with the 4.06 version of the OCaml compiler, while
-Melange is compatible with OCaml versions 4.14, 5.1.1, 5.2.x and 5.3.0 (as of
-February 2025).
+Melange 7 is compatible with OCaml 5.5 and includes the OCaml 5.5 standard
+library. Earlier Melange releases target earlier OCaml compiler versions; refer
+to their versioned documentation for the corresponding compiler version.
 
 ### Editor integration
 

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -158,7 +158,7 @@ in the project folder.
 If it does not exist, we can create it with:
 
 ```bash
-opam switch create . 5.3.0 --deps-only
+opam switch create . 5.5.0 --deps-only
 ```
 
 If it exists, we can install the dependencies of the project with:


### PR DESCRIPTION
Backports #244 to the v7.0.1 documentation branch.